### PR TITLE
Display the account address of unfunded accounts

### DIFF
--- a/app/templates/receive.html
+++ b/app/templates/receive.html
@@ -2,5 +2,5 @@
     <b>Receive stellars</b><br>
     <a ng-click="tab='none'">close</a>
     <hr>
-    {{$root.account.Account}}
+    {{$root.account.Account || $root.account}}
 </div>


### PR DESCRIPTION
`stellar-lib` leaves `account` as the address string for unfunded accounts, but expands funded accounts into an object with the address in the `Account` property.

Fixes #110
