### PR TITLE
Update password requirements

### DIFF
--- a/app/scripts/controllers/registration-controller.js
+++ b/app/scripts/controllers/registration-controller.js
@@ -27,11 +27,11 @@ sc.controller('RegistrationCtrl', function($scope, $state, session, bruteRequest
   delete passwordStrengthComputations.aspects.consecutive;
   delete passwordStrengthComputations.aspects.dictionary;
 
-  // Enforce 16 character minimum.
+  // Enforce 8 character minimum.
   passwordStrengthComputations.aspects.minLength = {
     weight: 100,
     strength: function(password){
-      var minLength = 16;
+      var minLength = 8;
       if(password.length < minLength/2) return 25;
       if(password.length < minLength) return 50;
       if(password.length < 2*minLength) return 75;

--- a/app/states/register.html
+++ b/app/states/register.html
@@ -56,7 +56,7 @@
                 <i class="username-status status glyphicon glyphicon-none" ng-class="passwordClass()"></i>
                 <span class="tip">
                     <a href="http://xkcd.com/936/" target="_blank" title="Password strength" tabindex="-1">
-                        Min of 16 characters.
+                        Min of 8 characters.
                     </a>
                 </span>
             </div>


### PR DESCRIPTION
The password strength is now based on password length.
Enforce minimum password length of 16 characters.
Change orange password status text from "OK" to "ALMOST".
Make password info a link to http://xkcd.com/936/.

Fixes #122.
