### PR TITLE
Construct the wallet from local storage

### DIFF
--- a/app/scripts/services/session.js
+++ b/app/scripts/services/session.js
@@ -46,7 +46,7 @@ sc.service('session', function($rootScope) {
   Session.prototype.loginFromStorage = function($scope) {
     if(localStorage.wallet) {
       try {
-        var wallet = JSON.parse(localStorage.wallet);
+        var wallet = new Wallet(JSON.parse(localStorage.wallet));
 
         if (wallet) {
           this.login(wallet);


### PR DESCRIPTION
The wallet stored in local storage is a flat object, but needs to be constructed into a `Wallet` object at login so it can be encrypted later.
