### PR TITLE
Update button hover styles

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -134,18 +134,21 @@ body {
   background-color: $white-grey;
   border-bottom-color: $grey;
   border-radius: 2px;
-  box-shadow: 0 -1px 0 0 $light-grey inset;
+  box-shadow: 0 -1px 0 0 rgba(black, 0.1) inset;
   @include transition(border-color 200ms ease-in-out,
                       background-color 200ms ease-in-out,
-                      color 200ms ease-in-out);
+                      color 200ms ease-in-out,
+                      box-shadow 200ms ease-in-out);
 
   &:hover {
     border-color: $stellar-blue;
-    background-color: $white-grey;
-    color: $stellar-blue;
+    background-color: $stellar-blue;
+    border-bottom-color: $dark-grey;
+    color: white;
+    box-shadow: 0 -1px 0 0 rgba(black, 0) inset;
 
     i {
-      color: $stellar-blue;
+      color: white;
     }
   }
 
@@ -155,7 +158,7 @@ body {
     color: $dark-grey;
 
     &:hover {
-      color: $stellar-blue;
+      color: white;
     }
   }
 


### PR DESCRIPTION
The button hover style was white with a blue outline, but now has a blue background with white text.

Fixes #134.
