### PR TITLE
Change border to border-style

### DIFF
--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -139,7 +139,7 @@
       cursor: default;
 
       &:before {
-        border: solid;
+        border-style: solid;
         border-color: $grey-border transparent;
         border-width: 0 10px 10px 10px;
         bottom: -7px;
@@ -149,7 +149,7 @@
       }
 
       &:after {
-        border: solid;
+        border-style: solid;
         border-color: white transparent;
         border-width: 0 10px 10px 10px;
         bottom: -8px;


### PR DESCRIPTION
When the css is minified it moved the `border-color` into a different block than the `border` property.
Since the `border` definition did not include a color attribute it defaulted to `initial`, and since the `border-color` definition is no longer in the block `initial` had a higher priority.

Changing `border` to `border-style` corrected the issue.

Fixes #138.
