### PR TITLE
Add error message for invalid send amounts

### DIFF
--- a/app/scripts/controllers/send-pane.js
+++ b/app/scripts/controllers/send-pane.js
@@ -415,9 +415,31 @@ sc.controller('SendPaneCtrl', ['$rootScope','$scope', '$routeParams', '$timeout'
         // inputs have changed.
         if (pathUpdateTimeout) $timeout.cancel(pathUpdateTimeout);
 
-        // If the form is invalid, we won't be able to submit anyway, so no point
-        // in calculating paths.
-        if ($scope.sendForm.$invalid) return;
+        // Don't calculate paths if the amount is empty.
+        if (send.amount == '') {
+            send.fund_status = 'empty';
+            return;
+        }
+
+        // Validate the send amount.
+        if (!stellar.Amount.is_valid(amount)) {
+            send.fund_status = 'invalid';
+            return;
+        }
+
+        // Send amount passed validation.
+        send.fund_status = 'none';
+
+        // Don't calculate paths if the recipient is empty.
+        if (recipient == '') {
+            return;
+        }
+
+        // Validate the recipient address.
+        if (!stellar.UInt160.is_valid(recipient)){
+            // Invalid address.
+            return;
+        }
 
         if (send.quote_url) {
             if (!send.amount_feedback.is_valid())
@@ -427,11 +449,6 @@ sc.controller('SendPaneCtrl', ['$rootScope','$scope', '$routeParams', '$timeout'
             send.amount_feedback.set_issuer(1);
             pathUpdateTimeout = $timeout($scope.update_quote, 500);
         } else {
-            if (!stellar.UInt160.is_valid(recipient) || !stellar.Amount.is_valid(amount)) {
-                // XXX Error?
-                return;
-            }
-
             // Create Amount object
             if (!send.amount_feedback.is_native()) {
                 send.amount_feedback.set_issuer(recipient);

--- a/app/templates/send.html
+++ b/app/templates/send.html
@@ -110,13 +110,16 @@
     </ul>  -->
     <div class="row">
         <div ng-show="send.currency_code == 'XTR'">
-            <button type="submit" ng-disabled="sendForm.$invalid || send.self || !send.recipient_resolved || account.max_spend.to_number() < send.amount * 1000000" l10n="l10n" class="btn btn-default submit col-sm-offset-3 col-sm-6 stellar-button">Send</button>
+            <button type="submit" ng-disabled="sendForm.$invalid || send.self || !send.recipient_resolved || account.max_spend.to_number() < send.amount * 1000000 || send.fund_status !== 'none'" l10n="l10n" class="btn btn-default submit col-sm-offset-3 col-sm-6 stellar-button">Send</button>
         </div>
     </div>
     <div class="remote">
         <p ng-show="send.fund_status == 'insufficient-xtr'" l10n="l10n" class="literal">
             Destination account is unfunded; send at least
             {{send.xtr_deficiency | rpamount}} XTR to fund it.<a href="https://wiki.gostellar.org/Reserves" target="_blank" l10n="l10n">More information</a>
+        </p>
+        <p ng-show="send.fund_status == 'invalid'" l10n="l10n" class="literal">
+            Send amount must be a number.
         </p>
         <p ng-show="account.max_spend.to_number() < send.amount * 1000000" l10n="l10n" class="literal">
             You need a reserve amount of 50 Stellars to send. <a href="https://wiki.gostellar.org/Reserves" target="_blank" l10n="l10n">More information</a>


### PR DESCRIPTION
Adds an error message when the send amount is not a valid number.
Disables the send button when the amount is invalid.

Note: The structure of the code in `send-pane.js` and `send.html` is horrendous and forces us to write bad code until it is rewritten.

Fixes #115.
