### PR TITLE
Convert transaction.amount to a number for sort

### DIFF
--- a/app/templates/transaction-history.html
+++ b/app/templates/transaction-history.html
@@ -15,7 +15,7 @@
                     <span class="type">{{ tx.transaction.type }}</span>
                 </td>
                 <td data-title="'Date'" sortable="'date'" am-time-ago="tx.date"></td>
-                <td data-title="'Amount'" sortable="'transaction.amount'">{{ tx.transaction.amount.to_human() }} XTR</td>
+                <td data-title="'Amount'" sortable="'transaction.amount.to_number()'">{{ tx.transaction.amount.to_human() }} XTR</td>
                 <td class="direction">{{ tx.transaction.type === 'sent' ? 'to' : 'from' }}</td>
                 <td class="other-party">
                     <span class="address">{{ tx.transaction.counterparty }}</span>


### PR DESCRIPTION
`transaction.sort` is a big integer that must be converted to a number before sorting.

Fixes #164.
