### PR TITLE
Add separate logout path

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -50,7 +50,7 @@
 
                 <ul class="nav navbar-nav navbar-right ng-hide" ng-show="session.get('loggedIn')">
                     <li><a href="#">{{ session.get('username') }}</a></li>
-                    <li><a href="#/login" ui-sref="login">LOG OUT</a></li>
+                    <li><a href="#/logout" ui-sref="logout">LOG OUT</a></li>
                 </ul>
             </div>
         </div>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -15,7 +15,7 @@ stellarClient.config(function($httpProvider, $stateProvider, $urlRouterProvider,
     .state('login', {
       url:         '/login',
       templateUrl: 'states/login.html',
-      authenticate: null
+      authenticate: false
     })
     .state('recovery', {
       url:         '/recovery',
@@ -31,6 +31,10 @@ stellarClient.config(function($httpProvider, $stateProvider, $urlRouterProvider,
       url:         '/register',
       templateUrl: 'states/register.html',
       authenticate: false
+    })
+    .state('logout', {
+      url:         '/logout',
+      authenticate: true
     })
     .state('dashboard', {
       url:         '/dashboard',
@@ -83,6 +87,12 @@ stellarClient.run(function($rootScope, $state, session){
             event.preventDefault();
             return;
           }
+        }
+        break;
+
+      case '/logout':
+        if(session.get('loggedIn')) {
+          session.logOut();
         }
         break;
 

--- a/app/scripts/controllers/login-controller.js
+++ b/app/scripts/controllers/login-controller.js
@@ -3,10 +3,6 @@
 var sc = angular.module('stellarClient');
 
 sc.controller('LoginCtrl', function($scope, $state, $http, $timeout, $q, session, singletonPromise) {
-  if(session.get('loggedIn')) {
-    session.logOut();
-  }
-
   $scope.username   = null;
   $scope.password   = null;
   $scope.loginError = null;


### PR DESCRIPTION
Add separate path for logout to prevent unwanted logouts when navigating to `/login`.
`/login` now redirects authenticated users to the dashboard like all the other unauthenticated paths.

Fixes #185.
