### PR TITLE
Remove dead other-party avatar styles

### DIFF
--- a/app/styles/transactionHistory.scss
+++ b/app/styles/transactionHistory.scss
@@ -55,26 +55,6 @@
           color: $grey;
           text-align: center;
         }
-
-        &.other-party {
-          padding: 13px 8px;
-
-          .avatar {
-            width: 40px;
-            height: 40px;
-            display: inline-block;
-            vertical-align: middle;
-            background-color: $grey;
-            border-radius: 40px;
-            overflow: hidden;
-            margin-right: 10px;
-
-            img {
-              width: 40px;
-              height: 40px;
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
The counterpart address/name was being mis-aligned by dead styles that should have been removed when the counter-party avatar was removed.

Fixes #213.
