### PR TITLE
Correct passwordErrors usage

### DIFF
--- a/app/templates/password.html
+++ b/app/templates/password.html
@@ -1,7 +1,7 @@
 <div class="password-container" ng-controller="PasswordCtrl">
     <div class="form-group">
         <div class="errors col-sm-12">
-            <div class="tip col-sm-offset-6 col-sm-3">{{ passwordErrors.join('\n') }}</div>
+            <div class="tip col-sm-offset-6 col-sm-3">{{ errors.passwordErrors.join('\n') }}</div>
         </div>
         <label for="password" class="col-sm-3">PASSWORD</label>
         <div class="col-sm-6">


### PR DESCRIPTION
When the password from was modularized `passwordErrors` became a property of `errors`, but wasn't updated in the template.

Fixes #249.
