### PR TITLE
Fix status and button for awaiting payment

### DIFF
--- a/app/templates/reward-page.html
+++ b/app/templates/reward-page.html
@@ -24,9 +24,9 @@
                 Oh, happy day.
             </div>
             <div class="info">
-                You need to complete the previous reward to get your coins.
+                You need to authenticate with facebook to get your coins.
             </div>
-            <button class="stellar-button btn btn-default" ng-click="closeReward()">Unlock previous?</button>
+            <button class="stellar-button btn btn-default" ng-click="toggleReward(1, rewards[1].status)">Get your first Stellars</button>
         </div>
 
         <div class="content sent" ng-class="{active: reward.status == 'sent'}">


### PR DESCRIPTION
When awaiting payout, the reward page should explain that you need to auth with facebook and the button should take you to the facebook reward page.

Fixes #236.
