### PR TITLE
Allow selecting text in the transaction history

### DIFF
--- a/app/scripts/controllers/transaction-history.js
+++ b/app/scripts/controllers/transaction-history.js
@@ -16,10 +16,11 @@ sc.controller('TransactionHistoryCtrl', function($scope)
   $scope.transactionGrid = {
     data: 'history',
     enableRowSelection: false,
+    enableHighlighting: true,
     plugins: [new ngGridFlexibleHeightPlugin()],
     headerRowHeight: '70',
     rowHeight: '70',
-    rowTemplate: '<div ng-style="{ \'cursor\': row.cursor }" ng-repeat="col in renderedColumns" ng-class="col.colIndex()" class="ngCell {{col.cellClass}}"><div class="ngVerticalBar" ng-style="{height: rowHeight}">&nbsp;</div><div ng-cell></div></div>',
+    rowTemplate: '<div ng-repeat="col in renderedColumns" ng-class="col.colIndex()" class="ngCell {{col.cellClass}}"><div class="ngVerticalBar" ng-style="{height: rowHeight}">&nbsp;</div><div ng-cell></div></div>',
     columnDefs: [
       {
         field: 'transaction.type',


### PR DESCRIPTION
I didn't notice that ngGrid prevents text selection by default.

This PR allows selecting text and displaying the correct cursor.
