### PR TITLE
The send button should open & reset the send form

### DIFF
--- a/app/scripts/controllers/dashboard-controller.js
+++ b/app/scripts/controllers/dashboard-controller.js
@@ -15,20 +15,13 @@ sc.controller('DashboardCtrl', function($rootScope, $scope, $timeout, $state, se
       $rootScope.tab = 'none';
     };
 
-    $scope.toggleSend = function() {
-        if ($rootScope.tab!='send') {
-            $rootScope.tab='send';
-        } else {
-            $rootScope.tab='none';
-        }
+    $scope.openSend = function() {
+        $scope.$broadcast('resetSendPane');
+        $rootScope.tab = 'send';
     };
 
-    $scope.toggleReceive = function() {
-        if ($rootScope.tab!='receive') {
-            $rootScope.tab='receive';
-        } else {
-            $rootScope.tab='none';
-        }
+    $scope.openReceive = function() {
+        $rootScope.tab = 'receive';
     };
 
     $scope.statusMessage = function(){

--- a/app/scripts/controllers/send-pane.js
+++ b/app/scripts/controllers/send-pane.js
@@ -8,11 +8,9 @@ sc.controller('SendPaneCtrl', ['$rootScope','$scope', '$routeParams', '$timeout'
 {
     var timer;
 
-
-    $scope.closePane = function(){
-      $scope.reset();
-      $rootScope.tab = 'none';
-    };
+    $scope.$on('resetSendPane', function() {
+        $scope.reset();
+    });
 
     $scope.changeMode = function(targetMode) {
         if (!$rootScope.connected) {

--- a/app/states/dashboard.html
+++ b/app/states/dashboard.html
@@ -13,13 +13,13 @@
                 <span ng-show="$root.accountStatus == 'loaded'" class="dash-balance-info ng-hide">Current Balance <b>Stellars</b></span>
             </div>
             <div class="dash-receive-container">
-                <button class="stellar-button btn btn-default" ng-click="toggleReceive()">
+                <button class="stellar-button btn btn-default" ng-click="openReceive()">
                     <i class="glyphicon glyphicon-download"></i>
                     Receive
                 </button>
             </div>
             <div class="dash-send-container">
-                <button class="stellar-button btn btn-default" ng-click="toggleSend()">
+                <button class="stellar-button btn btn-default" ng-click="openSend()">
                     <i class="glyphicon glyphicon-upload"></i>
                     Send
                 </button>


### PR DESCRIPTION
The "Send" and "Receive" buttons should open, but not close their respective panes.
The "Send" button should reset the send pane even if it is already open.

Fixes #299.
