### PR TITLE
Allow the last column to fill the remaining width

### DIFF
--- a/app/scripts/controllers/transaction-history.js
+++ b/app/scripts/controllers/transaction-history.js
@@ -53,7 +53,7 @@ sc.controller('TransactionHistoryCtrl', function($scope)
       {
         field: 'transaction.counterparty',
         displayName: '',
-        width: '35%',
+        width: '*',
         cellTemplate: '<span class="address">{{ row.getProperty(col.field) | addressToUsername }}</span>'
       }
     ]


### PR DESCRIPTION
Allow the counter party column to use the remaining with of the table.

Fixes #340.
