### PR TITLE
Allow angular to listen to autofill events

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -106,6 +106,7 @@
 <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
 <script src="bower_components/angular-debounce/dist/angular-debounce.min.js"></script>
 <script src="bower_components/angular-password-strength/build/angular-password-strength.min.js"></script>
+<script src="bower_components/autofill-event/src/autofill-event.js"></script>
 <script src="bower_components/crypto-js/components/core.js"></script>
 <script src="bower_components/crypto-js/components/ripemd160.js"></script>
 <script src="bower_components/moment/moment.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "angular-ui-router": "~0.2.10",
     "angular-debounce": "~0.0.3",
     "angular-password-strength": "~0.0.4",
+    "autofill-event": "~1.0.0",
     "crypto-js": "http://crypto-js.googlecode.com/files/CryptoJS%20v3.1.2.zip",
     "angular-moment": "~0.7.0",
     "fontawesome": "~4.1.0",


### PR DESCRIPTION
There is a long running know issue in angular/browsers that prevents angular from listening to autocomplete events.
https://github.com/angular/angular.js/issues/1460

The solution is a polyfill that triggers the change event even in browsers that don't have an autofill event.
https://github.com/tbosch/autofill-event
