### PR TITLE
Fix email reward input

### DIFF
--- a/app/styles/reward-page.scss
+++ b/app/styles/reward-page.scss
@@ -18,9 +18,9 @@
     border-bottom: 6px solid $error;
   }
 
-  .reward-container-title {
+  .reward-page-title {
     font-weight: $avenir-heavy;
-    font-size: 20px;
+    font-size: 16px;
     height: 50px;
     line-height: 50px;
     margin-bottom: 42px;
@@ -59,7 +59,7 @@
     .body,
     .info {
       font-weight: $avenir-medium;
-      font-size: 20px;
+      font-size: 16px;
       text-align: center;
     }
 
@@ -70,7 +70,7 @@
     .verify-email {
       position: relative;
       overflow: hidden;
-      height: 152px;
+      height: 165px;
 
       .add-email-item {
         left: -110%;
@@ -151,6 +151,21 @@
     .errorButton button {
       width: 270px;
       margin-top: 20px;
+    }
+  }
+}
+
+@media (min-width: $mobile-width) {
+  .reward-page {
+    .reward-page-title {
+      font-size: 20px;
+    }
+
+    .content{
+      .body,
+      .info {
+        font-size: 20px;
+      }
     }
   }
 }

--- a/app/templates/reward-page.html
+++ b/app/templates/reward-page.html
@@ -3,7 +3,7 @@
         <span>Close</span>
         <i class="icon icon-times-circle-thin"></i>
     </div>
-    <div class="reward-container-title">
+    <div class="reward-page-title">
         <i class="icon icon-lock"></i>
         <span>{{ reward.innerTitle }}</span>
     </div>


### PR DESCRIPTION
Prevent the email reward inputs from flowing off the right side of the pane.
Prevent the email reward buttons from flowing off the bottom of the pane by making the font size responsive.
Fix incorrect class name.

Fixes #362.
