### PR TITLE
Integrates gulp-rev and gulp-rev-replace to add content-based naming

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,9 +81,11 @@ gulp.task('html', ['config', 'styles', 'scripts', 'templateCache'], function (do
             .pipe($.replace('bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap','fonts'))
             .pipe($.csso())
             .pipe(cssFilter.restore())
+            .pipe($.rev())   
             .pipe($.useref.restore())
             .pipe($.useref())
 
+            .pipe($.revReplace())
             .pipe(gulp.dest('dist'))
             .pipe($.size())
             .once('end', done)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "tmp": "0.0.23",
     "bower": "1.3.6",
     "connect": "^2.14.4",
     "connect-livereload": "^0.4.0",
@@ -27,6 +26,8 @@
     "gulp-plumber": "^0.6.1",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.3.0",
+    "gulp-rev": "^0.4.2",
+    "gulp-rev-replace": "^0.2.1",
     "gulp-sass": "^0.7.2",
     "gulp-size": "^0.3.0",
     "gulp-uglify": "^0.2.1",
@@ -40,6 +41,7 @@
     "merge-stream": "^0.1.1",
     "mocha": "^1.20.1",
     "opn": "^0.1.1",
+    "tmp": "0.0.23",
     "wiredep": "^1.4.3"
   },
   "engines": {


### PR DESCRIPTION
This PR integrates gulp-rev and gulp-rev-replace.  These two plugins allow us to be much more aggressive with our client-side caching of css and javascript.

These plugins modify the compiled js and css files such that their names incorporate a partial hash of their content, and it also replaces references to that js/css with those new filenames.  Since the filenames (and references to them) change whenever the content changes, we can aggressively cache any given filename because its content will never change.
