### PR TITLE
Create flash messages below balance

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -169,6 +169,7 @@
 <script src="scripts/controllers/facebook-reward-controller.js"></script>
 <script src="scripts/controllers/email-reward-controller.js"></script>
 <script src="scripts/controllers/send-reward-controller.js"></script>
+<script src="scripts/controllers/flash-message-controller.js"></script>
 
 <script src="scripts/directives/directives.js"></script>
 <script src="scripts/directives/validators.js"></script>

--- a/app/scripts/controllers/flash-message-controller.js
+++ b/app/scripts/controllers/flash-message-controller.js
@@ -1,0 +1,15 @@
+/**
+ * To show flash messages broadcast a "flashMassage" event with an object
+ * containing a title, info, and optional type ("error" or "success").
+ */
+sc.controller('FlashMessageCtrl', function ($scope, $rootScope) {
+  $scope.messages = [];
+
+  $rootScope.$on('flashMessage', function(e, message) {
+    $scope.messages.push(message);
+  });
+
+  $scope.dismissMessage = function(index) {
+    $scope.messages.splice(index, 1);
+  };
+});

--- a/app/states/dashboard.html
+++ b/app/states/dashboard.html
@@ -49,5 +49,6 @@
     <div class="send-container client-section" ng-include="'templates/send.html'" ng-show="tab==='send'"></div>
     <div class="receive-container client-section" ng-include="'templates/receive.html'" ng-show="$root.tab==='receive'"></div>
 </div>
+<div ng-include="'templates/flash-message-container.html'"></div>
 <div ng-include="'templates/reward-container.html'"></div>
 <div ng-include="'templates/transaction-history.html'"></div>

--- a/app/styles/flash-message.scss
+++ b/app/styles/flash-message.scss
@@ -1,0 +1,76 @@
+.flash-message-container {
+  background-color: $grey-background;
+  padding-top: 28px;
+  padding-bottom: 28px;
+
+  &:empty {
+    display: none;
+  }
+
+  .flash-message {
+    border: 1px solid $stellar-blue;
+    border-radius: 2px;
+    padding-top: 8px;
+    margin-bottom: 20px;
+    position: relative;
+    background-color: white;
+    box-shadow: 0 1px 6px 6px rgba($grey, 0.1),
+                0 1px 2px 2px rgba($grey, 0.2);
+
+    &.error {
+      border-color: $error;
+
+      .flash-title {
+        color: $error;
+      }
+
+      .flash-accent {
+        background-color: $error;
+      }
+    }
+
+    &.success {
+      border-color: $success;
+
+      .flash-title {
+        color: $success;
+      }
+
+      .flash-accent {
+        background-color: $success;
+      }
+    }
+
+    .flash-title,
+    .flash-info {
+      display: block;
+      margin: 6px 40px;
+    }
+
+    .flash-title {
+      font-size: 20px;
+      font-weight: $avenir-medium;
+      color: $stellar-blue;
+    }
+
+    .flash-info {
+      font-size: 16px;
+      margin-bottom: 14px;
+    }
+
+    .icon-close {
+      font-size: 26px;
+      color: $grey;
+      position: absolute;
+      padding: 18px 20px;
+      right: 0;
+      cursor: pointer;
+    }
+
+    .flash-accent {
+      width: 100%;
+      height: 4px;
+      background-color: $stellar-blue;
+    }
+  }
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -21,6 +21,7 @@ $mobile-width: 992px;
 @import "reward-container.scss";
 @import "pane.scss";
 @import "modalStatus.scss";
+@import "flash-message.scss";
 
 body {
   height: 100%;

--- a/app/templates/flash-message-container.html
+++ b/app/templates/flash-message-container.html
@@ -1,0 +1,8 @@
+<div class="flash-message-container client-section" ng-show="messages.length" ng-controller="FlashMessageCtrl">
+    <div ng-repeat="message in messages" class="flash-message" ng-class="message.type">
+        <i class="icon icon-close" ng-click="dismissMessage($index)"></i>
+        <span class="flash-title">{{ message.title }}</span>
+        <span class="flash-info">{{ message.info }}</span>
+        <div class="flash-accent"></div>
+    </div>
+</div>


### PR DESCRIPTION
Creates flash messages below the balance.
Flash messages are created by broadcasting the `flashMessage` event.
The `flashMessage` event accepts an object with the following properties:
- {string} `title`
- {string} `info`
- {string} `type` (optional) ["error", "success"]

Fixes #232.

![screen shot 2014-07-16 at 7 59 53 pm](https://cloud.githubusercontent.com/assets/3108007/3608386/86bde9e4-0d5e-11e4-95f0-64144ec430f8.png)
