### PR TITLE
Keep the padding on the login inputs

### DIFF
--- a/app/styles/login.scss
+++ b/app/styles/login.scss
@@ -1,14 +1,10 @@
 .login {
   padding-bottom: 80px;
 
-  .col-sm-6 {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
   .input-icon-wrapper {
     .icon {
       color: #D8D8D8;
+      margin-right: 15px;
     }
 
     .icon-user {


### PR DESCRIPTION
Removing the padding on the login inputs looked bad.
Add padding to the input icons.
