### PR TITLE
Abort unnecessary recipient change events

### DIFF
--- a/app/scripts/controllers/send-pane.js
+++ b/app/scripts/controllers/send-pane.js
@@ -50,7 +50,11 @@ sc.controller('SendPaneCtrl', ['$rootScope','$scope', '$routeParams', '$timeout'
     // {name: "XRP - Ripples", order: 146, value: "XRP"}
     $scope.xtr = _.where($scope.currencies_all, {value: "STR"})[0];
 
-    $scope.$watch('send.recipient', function () {
+    $scope.$watch('send.recipient', function (newVal, oldVal) {
+        if (newVal == oldVal || !newVal) {
+            return;
+        }
+        
         // raw address without any parameters
         var address = webutil.stripRippleAddress($scope.send.recipient);
 


### PR DESCRIPTION
Angular's `$watch` will fire for any assignment including the same value.
It is a [common angular code pattern](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#example) to return immediately if the value didn't actually change.
If an empty recipient is given, the "Please enter a recipient." error will take over, and the rest of the watch code path is irrelevant.

Fixes #403.
