### PR TITLE
Fix tx listener

### DIFF
--- a/app/scripts/controllers/send-reward-controller.js
+++ b/app/scripts/controllers/send-reward-controller.js
@@ -45,6 +45,7 @@ sc.controller('SendRewardCtrl', function ($rootScope, $scope, $http, stNetwork, 
   function removeSentTxListener() {
     if (turnOffTxListener) {
       turnOffTxListener();
+      turnOffTxListener = null;
     }
   }
 


### PR DESCRIPTION
For some reason multiple calls to a listener's deregistration function are causing other listeners to the same event to be turned off. This seems to be an angular bug, but we removing the deregistration function after it's called fixes the issue.

Fixes #393.
