### PR TITLE
Quit trying to send if the account is undefined

### DIFF
--- a/app/scripts/controllers/send-pane.js
+++ b/app/scripts/controllers/send-pane.js
@@ -499,6 +499,10 @@ sc.controller('SendPaneCtrl', ['$rootScope','$scope', '$routeParams', '$timeout'
                 return;
             }
 
+            if (!$scope.account) {
+                return;
+            }
+
             // Cannot make STR payment if the sender does not have enough STR
             send.sender_insufficient_xtr = send.amount_feedback.is_native()
                 && $scope.account.max_spend


### PR DESCRIPTION
The send pane is trying to validate a transaction when there is no account loaded.
TODO: Rebuild the send pane.
