### PR TITLE
Destroy the app on logout by reloading the page

### DIFF
--- a/app/scripts/services/session.js
+++ b/app/scripts/services/session.js
@@ -101,6 +101,11 @@ sc.service('session', function($rootScope, $http, $timeout, stNetwork, Wallet) {
     delete $rootScope.account;
     stNetwork.shutdown();
     this.clearIdleTimeout();
+
+    // HACK: Ensure that the app's state is reset by reloading the page.
+    if (Options.LOGOUT_WITH_REFRESH) {
+      location.reload();
+    }
   };
 
   function checkFairyAddress() {

--- a/config/dev.js
+++ b/config/dev.js
@@ -37,5 +37,7 @@ var Options = {
     REPORT_ERRORS : false,
     SENTRY_DSN : "https://5c08986e949742d2bb29e1ffac78e50a@app.getsentry.com/26645",
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50
+    transactions_per_page: 50,
+
+    LOGOUT_WITH_REFRESH: true
 };

--- a/config/prd.js
+++ b/config/prd.js
@@ -34,5 +34,7 @@ var Options = {
     SENTRY_DSN : "https://5c08986e949742d2bb29e1ffac78e50a@app.getsentry.com/26645",
 
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50
+    transactions_per_page: 50,
+
+    LOGOUT_WITH_REFRESH: true
 };

--- a/config/stg.js
+++ b/config/stg.js
@@ -35,5 +35,7 @@ var Options = {
     REPORT_ERRORS : true,
     SENTRY_DSN : "https://4574695240794dc090caaa3f2d02fd6c@app.getsentry.com/27687",
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50
+    transactions_per_page: 50,
+
+    LOGOUT_WITH_REFRESH: true
 };


### PR DESCRIPTION
Prevent outstanding requests, callbacks, and digests after logout by forcing the page to reload.
