### PR TITLE
Set the default transaction pages size to 25

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -37,7 +37,7 @@ var Options = {
     REPORT_ERRORS : false,
     SENTRY_DSN : "https://5c08986e949742d2bb29e1ffac78e50a@app.getsentry.com/26645",
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50,
+    transactions_per_page: 25,
 
     LOGOUT_WITH_REFRESH: true
 };

--- a/config/prd.js
+++ b/config/prd.js
@@ -34,7 +34,7 @@ var Options = {
     SENTRY_DSN : "https://5c08986e949742d2bb29e1ffac78e50a@app.getsentry.com/26645",
 
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50,
+    transactions_per_page: 25,
 
     LOGOUT_WITH_REFRESH: true
 };

--- a/config/stg.js
+++ b/config/stg.js
@@ -35,7 +35,7 @@ var Options = {
     REPORT_ERRORS : true,
     SENTRY_DSN : "https://4574695240794dc090caaa3f2d02fd6c@app.getsentry.com/27687",
     // Number of transactions each page has in balance tab notifications
-    transactions_per_page: 50,
+    transactions_per_page: 25,
 
     LOGOUT_WITH_REFRESH: true
 };


### PR DESCRIPTION
Set the default transaction pages size to 25.

Fixes #471.
