### PR TITLE
Change title on Stellar client pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" ng-app="stellarClient">
 <head>
     <meta charset="utf-8">
-    <title>stellar client</title>
+    <title>Stellar</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/png" href="/images/favicon.png">


### PR DESCRIPTION
Normal users don't care that the client is a separate repository from the server, so there's no reason to specify that in the title.
