### PR TITLE
Registration failure

### DIFF
--- a/app/scripts/controllers/registration-controller.js
+++ b/app/scripts/controllers/registration-controller.js
@@ -287,19 +287,18 @@ sc.controller('RegistrationCtrl', function($scope, $state, $timeout, $http, $q, 
 
     // Upload the new wallet to the server.
     return wallet.sync('create').catch(function(err) {
-      var data = {
-        username: $scope.data.username,
-        email: $scope.data.email
-      };
-
       if (attempts >= Options.MAX_WALLET_ATTEMPTS) {
         FlashMessages.add({
           title: 'Registration Error',
-          info: 'There was an error during registration. Please contact us at hello@stellar.org to retrieve your account.',
+          info: 'There was an error during registration. Please contact us at hello@stellar.org if the problem persists.',
           type: 'error'
         });
 
-        $http.post(Options.API_SERVER + "/failedRegistration", data);
+        $http.post(Options.API_SERVER + "/failedRegistration", {
+          username: $scope.data.username,
+          updateToken: wallet.keychainData.updateToken,
+          email: $scope.data.email
+        });
 
         return $q.reject();
       }


### PR DESCRIPTION
Add a default max number of attempts to prevent an infinite loop for developers that have a stale config file.
Add increasing delay to wallet create attempts to improve the chances of the request going through.
Provide the updateToken in the failedRegistration request so that the user record can be deleted.
Update the failure message to encourage users to retry and contact us if the issue persists.
