### PR TITLE
Show message when logged out due to inactivity

### DIFF
--- a/app/scripts/controllers/app-controller.js
+++ b/app/scripts/controllers/app-controller.js
@@ -26,18 +26,6 @@ sc.controller('AppCtrl', function($scope, $rootScope, stNetwork, session, $state
         }
     });
 
-    $scope.$on('idleLogout', function(e, args) {
-        var loggedOutAt = args.loggedOutAt;
-
-        $state.transitionTo('logout');
-        FlashMessages.add({
-            title: 'You\'ve been logged out',
-            info: 'For your security, you have been logged out because your browser is idle. Please log back in to continue using Stellar.',
-            type: 'error'
-        });
-
-    });
-
     $($element).click(function(){ session.act(); });
     $($element).keypress(function(){ session.act(); });
 

--- a/app/scripts/controllers/login-controller.js
+++ b/app/scripts/controllers/login-controller.js
@@ -15,6 +15,14 @@ sc.controller('LoginCtrl', function($scope, $state, $http, $timeout, $q, session
     return deriveId().then(performLogin);
   });
 
+  if(location.search.match('idle')) {
+    FlashMessages.add({
+      title: 'You\'ve been logged out',
+      info: 'For your security, you have been logged out because your browser is idle. Please log back in to continue using Stellar.',
+      type: 'error'
+    });
+  }
+
   function deriveId() {
     //TODO: actually make Wallet.deriveId Promiseable
     //HACK: use timeout to turn an expensive synchronous operation into a promise

--- a/app/scripts/services/session.js
+++ b/app/scripts/services/session.js
@@ -34,8 +34,7 @@ sc.service('session', function($rootScope, $http, $timeout, stNetwork, Wallet) {
     var self = this;
 
     this.idleTimeout = $timeout(function() {
-      self.logout();
-      $rootScope.$broadcast('idleLogout', {loggedOutAt: new Date()});
+      self.logout(true);
     }, Options.IDLE_LOGOUT_TIMEOUT || 15 * 60 * 1000);
   };
 
@@ -87,20 +86,25 @@ sc.service('session', function($rootScope, $http, $timeout, stNetwork, Wallet) {
     }
   };
 
-  Session.prototype.logout = function() {
+  Session.prototype.logout = function(idle) {
     try {
       sessionStorage['display_reload_message'] = false;
     } catch (e) {}
 
     Wallet.purgeLocal();
-    cache = {};
-    delete $rootScope.account;
-    stNetwork.shutdown();
-    this.clearIdleTimeout();
 
     // HACK: Ensure that the app's state is reset by reloading the page.
     if (Options.LOGOUT_WITH_REFRESH) {
-      location.reload();
+      if(idle) {
+        location.search = 'idle';
+      } else {
+        location.href = location.origin;
+      }
+    } else {
+      cache = {};
+      delete $rootScope.account;
+      stNetwork.shutdown();
+      this.clearIdleTimeout();
     }
   };
 


### PR DESCRIPTION
The reload hack was clearing the message that tells users they were logged out due to inactivity.
This replaces the broadcasted event with a URL parameter that refreshes the page and signifies that the page was logged out due to inactivity.

Fixes #491.
