### PR TITLE
If the mainData gets corrupted, reset it

### DIFF
--- a/app/scripts/utilities/wallet.js
+++ b/app/scripts/utilities/wallet.js
@@ -22,8 +22,15 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, ipCookie) 
   Wallet.decrypt = function(encryptedWallet, id, key){
     var rawKey = sjcl.codec.hex.toBits(key);
 
-    var mainData = Wallet.decryptData(encryptedWallet.mainData, rawKey);
     var keychainData = Wallet.decryptData(encryptedWallet.keychainData, rawKey);
+    var mainData;
+    try {
+      mainData = Wallet.decryptData(encryptedWallet.mainData, rawKey);
+    } catch(err) {
+      // If the mainData get corrupted, reset it.
+      // https://github.com/stellar/stellar-client/issues/566
+      mainData = {};
+    }
 
     var options = {
       id:           id,


### PR DESCRIPTION
There was an error in the wallet database that truncated some user's mainData when their contact list got really long.
When the mainData fails to decrypt, reset it. The contact list will be rebuilt automatically.

Fixes #566.
