### PR TITLE
fairyTxListener needs contact.getContactsByEmail

### DIFF
--- a/app/scripts/services/contacts.js
+++ b/app/scripts/services/contacts.js
@@ -56,6 +56,16 @@ sc.service('contacts', function($q, rpFederation, rpReverseFederation) {
   }
 
   /**
+   * Returns the federation record for a given email or undefined.
+   *
+   * This function does not make federation requests and is suitable for
+   * use in filters and other synchronous code.
+   */
+  function getContactByEmail(email) {
+    return contactsByEmail[email];
+  }
+
+  /**
    * Returns a promise to the federation record for a given address.
    *
    * If there is no record in the cache or the record is too old,
@@ -118,6 +128,7 @@ sc.service('contacts', function($q, rpFederation, rpReverseFederation) {
   return {
     addContact: addContact,
     getContactByAddress: getContactByAddress,
+    getContactByEmail: getContactByEmail,
     fetchContactByAddress: fetchContactByAddress,
     fetchContactByEmail: fetchContactByEmail
   }


### PR DESCRIPTION
#580 used `contacts.getContactByEmail()` in the `fairyTxListener`, but never implemented it.

Implement `contacts.getContactByEmail()`.
