### PR TITLE
Fix current page was last page edge case

### DIFF
--- a/app/scripts/services/transactionHistory.js
+++ b/app/scripts/services/transactionHistory.js
@@ -113,8 +113,6 @@ sc.service('transactionHistory', function($rootScope, $q, stNetwork, session, co
     if (!_.any(data.transactions)) {
       allTransactionsLoaded = true;
     }
-
-    $rootScope.$broadcast('transactionHistory.historyUpdated');
   }
 
   /**


### PR DESCRIPTION
There was a rare edge case in #589 that caused `currentPage` to increment past `lastPage` when the last page of transactions was full and the you clicked next. The only noticeable affect was that when a new transaction was received, after the edge case was hit, the transaction history would switch to the last page instead of staying on the current page.

Always request one more page than needed so that we can detect when we get to the last page.
