### PR TITLE
Hide reward pane when all completed

### DIFF
--- a/app/scripts/controllers/reward-pane.js
+++ b/app/scripts/controllers/reward-pane.js
@@ -30,7 +30,7 @@ sc.controller('RewardPaneCtrl', function ($http, $scope, $rootScope, $q, session
 
   // HACK: Reward type 4 requires the user to claim, but has no interface.
   $scope.rewards[4] = {
-    status: 'incomplete',
+    status: 'sent',
     hidden: true,
     updateReward: function(status) {
       $scope.rewards[4].status = status;


### PR DESCRIPTION
When all rewards are completed it's good idea to hide "Get Started" pane. In a near future, users will need a quick access to last transactions table. It's an issue especially on mobile where users need to scroll the view to see a list of transactions:

![screenshot_2014-08-09-16-46-50](https://cloud.githubusercontent.com/assets/464938/3866506/936c4978-1fd4-11e4-9319-7fddbbd8a77c.png)

![screenshot_2014-08-09-16-47-07](https://cloud.githubusercontent.com/assets/464938/3866507/9759d62c-1fd4-11e4-87e7-a512b63c60d2.png)

The code responsible for hiding "Get Started" container was ready, however because of the hack in [`reward-pane.js`](https://github.com/bartekn/stellar-client/blob/hide-reward-pane/app/scripts/controllers/reward-pane.js#L31) file:

``` js
  // HACK: Reward type 4 requires the user to claim, but has no interface.
  $scope.rewards[4] = {
    status: 'incomplete',
    hidden: true,
    updateReward: function(status) {
      $scope.rewards[4].status = status;
    }
  };
```

the container is not being hidden. I checked a code and couldn't find any function which changes a status of this reward. Also, request to API `/user/rewards` resource returns information about only 3 of rewards. I left additional reward in case it will be finished in future.
