### PR TITLE
transactionHistory history flush fix

### DIFF
--- a/app/scripts/services/transactionHistory.js
+++ b/app/scripts/services/transactionHistory.js
@@ -5,13 +5,13 @@ var sc = angular.module('stellarClient');
 sc.service('transactionHistory', function($rootScope, $q, stNetwork, session, contacts) {
   // TODO: move history to an object, mapping hash -> transaction
   // then use an array of hashes to establish order
-  var history = [];
+  var history;
 
   var remote;
   var account;
 
-  var currentOffset = 0;
-  var allTransactionsLoaded = false;
+  var currentOffset;
+  var allTransactionsLoaded;
 
   /**
    * Initializes the transaction history once the network is connected.
@@ -21,6 +21,8 @@ sc.service('transactionHistory', function($rootScope, $q, stNetwork, session, co
 
     function initHistory() {
       history = [];
+      currentOffset = 0;
+      allTransactionsLoaded = false;
 
       remote = stNetwork.remote;
       account = remote.account(session.get('address'));


### PR DESCRIPTION
There was a bug in `transactionHistory` service. In `initHistory` function `history` array was flushed but `currentOffset` and `allTransactionsLoaded` variables were not. So when app executed `init` function for the second time (for example when user was coming back from `/settings` to `/dashboard`), history was removed but it was not reloaded and because of that "My transaction" container was not showing up.
