### PR TITLE
FB button fix

### DIFF
--- a/app/styles/fbconnect.scss
+++ b/app/styles/fbconnect.scss
@@ -3,7 +3,6 @@
   text-align: center;
 
   .fbbutton {
-    width: 275px;
     line-height: 24px;
     color: white;
     background-color: #3C569B;


### PR DESCRIPTION
`<button>` is too narrow:
![screenshot from 2014-08-14 21 15 27](https://cloud.githubusercontent.com/assets/464938/3925460/bc4df654-23e7-11e4-89fc-92088764c0ad.png)
(Chromium 36.0.1985.125 Ubuntu 14.04)
