### PR TITLE
Sync ensureEntropy(), always call before random()

### DIFF
--- a/app/scripts/controllers/registration-controller.js
+++ b/app/scripts/controllers/registration-controller.js
@@ -157,7 +157,6 @@ sc.controller('RegistrationCtrl', function($rootScope, $scope, $state, $statePar
 
   $scope.attemptRegistration = singletonPromise(function() {
     return validateInput()
-      .then(ensureEntropy)
       .then(submitRegistration)
       .then(createWallet)
       .then(function(){
@@ -175,43 +174,6 @@ sc.controller('RegistrationCtrl', function($rootScope, $scope, $state, $statePar
         $state.go('dashboard');
       });
   });
-
-
-  /**
-   * Seed the sjcl random function with Math.random() in the case where we are
-   * on a crappy browser (IE) and we've yet to get enough entropy from the
-   * sjcl entropy collector.
-   *
-   * it sucks, but this is our last minute fix for IE support.  Our fix going
-   * forward will be to use window.msCrypto on ie11, and on ie10 request
-   * some mouse movement from the user (maybe?).
-   *
-   */
-  function ensureEntropy() {
-    var deferred = $q.defer();
-
-    var isEnough = function() {
-      return sjcl.random.isReady() !== sjcl.random._NOT_READY;
-    }
-
-    if(isEnough()){
-      deferred.resolve();
-      return deferred.promise;
-    }
-
-    for (var i = 0; i < 8; i++) {
-      sjcl.random.addEntropy(Math.random(), 32, "Math.random()");
-    }
-
-    if(isEnough()){
-      deferred.resolve();
-    } else {
-      $scope.errors.usernameErrors.push('Couldn\'t get enough entropy');
-      deferred.reject();
-    }
-
-    return deferred.promise;
-  }
 
   function submitRegistration() {
     signingKeys = new SigningKeys();

--- a/app/scripts/utilities/signingKeys.js
+++ b/app/scripts/utilities/signingKeys.js
@@ -8,6 +8,7 @@ var SigningKeys = function(seed){
   if(seed){
     seed = new stellar.Seed().parse_json(seed);
   } else {
+    Util.ensureEntropy();
     seed = new stellar.Seed().random();
   }
 

--- a/app/scripts/utilities/util.js
+++ b/app/scripts/utilities/util.js
@@ -36,3 +36,31 @@ Util.showTooltip = function (element, title, type, placement) {
       element.tooltip('destroy');
     }, 2000);
 }
+
+/**
+ * Seed the sjcl random function with Math.random() in the case where we are
+ * on a crappy browser (IE) and we've yet to get enough entropy from the
+ * sjcl entropy collector.
+ *
+ * it sucks, but this is our last minute fix for IE support.  Our fix going
+ * forward will be to use window.msCrypto on ie11, and on ie10 request
+ * some mouse movement from the user (maybe?).
+ *
+ */
+Util.ensureEntropy = function() {
+  var isEnough = function() {
+    return sjcl.random.isReady() !== sjcl.random._NOT_READY;
+  }
+
+  if(isEnough()){
+    return;
+  }
+
+  for (var i = 0; i < 8; i++) {
+    sjcl.random.addEntropy(Math.random(), 32, "Math.random()");
+  }
+
+  if(!isEnough()) {
+    throw "Unable to seed sjcl entropy pool";
+  }
+}

--- a/app/scripts/utilities/wallet.js
+++ b/app/scripts/utilities/wallet.js
@@ -197,6 +197,8 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, ipCookie) 
 
   Wallet.prototype.saveLocal = function() {
     var self = this;
+
+    Util.ensureEntropy();
     var loginWalletKey = sjcl.random.randomWords(Wallet.SETTINGS.KEY_SIZE / 4);
     var encryptedWalletKey = Wallet.encryptData(this.key, loginWalletKey);
 
@@ -389,6 +391,7 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, ipCookie) 
     var cipher = new sjcl.cipher[Wallet.SETTINGS.CIPHER_NAME](key);
 
     // Encrypt the blob data in CCM mode using AES and a random 96bit IV.
+    Util.ensureEntropy();
     var rawIV = sjcl.random.randomWords(3);
     var rawCipherText = sjcl.mode[Wallet.SETTINGS.MODE].encrypt(cipher, rawData, rawIV);
 


### PR DESCRIPTION
Make sure sjcl has enough entropy to generate random numbers.
We added this to registration, but it should be called in the other locations that call random also.
