### PR TITLE
Keep a list of account lines with nonzero balances

### DIFF
--- a/app/scripts/controllers/dashboard-controller.js
+++ b/app/scripts/controllers/dashboard-controller.js
@@ -12,6 +12,7 @@ sc.controller('DashboardCtrl', function($rootScope, $scope, $timeout, $state, se
     $scope.tutorials = TutorialHelper;
 
     $scope.accountLines = [];
+    $scope.nonZeroAccountLines = [];
     $scope.balances = {};
     $scope.currencies = [];
     $scope.topCurrencies = [];
@@ -95,13 +96,15 @@ sc.controller('DashboardCtrl', function($rootScope, $scope, $timeout, $state, se
         $scope.accountLines = accountLines;
         $scope.balances = {};
 
-        accountLines.forEach(function(accountLine) {
-            var balance = Number(accountLine.balance);
+        // Filter out account lines with zero balances.
+        $scope.nonZeroAccountLines = accountLines.filter(function(accountLine) {
+            return accountLine.balance != '0';
+        });
 
-            if (balance != 0) {
-                var currency = accountLine.currency;
-                $scope.balances[currency] = ($scope.balances[currency] || 0) + balance;
-            }
+        $scope.nonZeroAccountLines.forEach(function(accountLine) {
+            var balance = Number(accountLine.balance);
+            var currency = accountLine.currency;
+            $scope.balances[currency] = ($scope.balances[currency] || 0) + balance;
 
             contacts.fetchContactByAddress(accountLine.account);
         });

--- a/app/states/dashboard.html
+++ b/app/states/dashboard.html
@@ -23,7 +23,7 @@
                             <div class="currency-balance col-xs-6">{{ balances[currency] }}</div>
                         </div>
                         <div class="dash-links">
-                            <a class="manage-currency-link" ng-click="openBalances();" href="#">view all balances ({{ accountLines.length + 1 }})</a>
+                            <a class="manage-currency-link" ng-click="openBalances();" href="#">view all balances ({{ nonZeroAccountLines.length + 1 }})</a>
                         </div>
                     </div>
                 </div>

--- a/app/templates/balances.html
+++ b/app/templates/balances.html
@@ -12,7 +12,7 @@
                 <h5>{{ balance | rpamount:{rel_precision: 0} }}</h5>
                 <p>{{ 'STR' | currencyName }}</p>
             </li>
-            <li ng-repeat="accountLine in accountLines" ng-if="accountLine.balance != '0'" class="currency-box">
+            <li ng-repeat="accountLine in nonZeroAccountLines" class="currency-box">
                 <h5>{{ accountLine.balance }}</h5>
                 <p>{{ accountLine.currency | currencyName }}</p>
                 <p class="currency-issuer">{{ accountLine.account | addressToUsername }}</p>


### PR DESCRIPTION
The balance count was incorrectly including account lines with zero balances.
Keep a filtered list of non-zero account lines and use it where non-zero balances are expected.

Fixes #735.
