### PR TITLE
Reverse federate the send address, but don't block

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -218,6 +218,7 @@
 <script src="scripts/services/bad_passwords.js"></script>
 <script src="scripts/services/action_link.js"></script>
 <script src="scripts/services/gateways-service.js"></script>
+<script src="scripts/services/whileValid.js"></script>
 
 <!-- endbuild -->
 </body>

--- a/app/scripts/controllers/send-form-controller.js
+++ b/app/scripts/controllers/send-form-controller.js
@@ -2,7 +2,7 @@
 
 var sc = angular.module('stellarClient');
 
-sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, stNetwork, contacts) {
+sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, stNetwork, contacts, whileValid) {
 
     // This object holds the raw send form data entered by the user.
     $scope.sendFormModel = {};
@@ -92,14 +92,13 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, s
             $scope.send.destination.destinationTag = destinationTag;
         }
 
-        $q.when(isValidAddress(address))
-        .then(function (isAddress) {
-            // check we're still current
+        whileValid(function() {
             if (inputHasChanged()) {
                 return $q.reject("not-current");
             }
-
-            if (isAddress) {
+        })
+        .then(function () {
+            if (isValidAddress(address)) {
                 contacts.fetchContactByAddress(address)
                     .then(function(result) {
                         $scope.send.federatedName = result.destination;
@@ -116,10 +115,6 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, s
             }
         })
         .then(function (result) {
-            // check we're still current
-            if (inputHasChanged()) {
-                return $q.reject("not-current");
-            }
             if (typeof result === "string") {
                 address = result;
             } else if (result) {
@@ -143,11 +138,6 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, s
             }
         })
         .then(function () {
-            // check we're still current
-            if (inputHasChanged()) {
-                return $q.reject("not-current");
-            }
-
             if(input !== address) {
                 showAddressFound($scope.send.destination.address);
             }

--- a/app/scripts/services/whileValid.js
+++ b/app/scripts/services/whileValid.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var sc = angular.module('stellarClient');
+
+/**
+ * Creates a promise chain that runs a validator before each
+ * function to determine if the chain should continue or reject.
+ */
+sc.service('whileValid', function($q) {
+  var ValidatedPromise = function(validator) {
+    this.validator = validator;
+    this.promiseChain = $q.when();
+  };
+
+  ValidatedPromise.prototype.then = function(next, err) {
+    this.promiseChain = this.promiseChain
+      .then(function(result) {
+        return $q.when(this.validator())
+          .then(next.bind(null, result), err);
+      }.bind(this), err);
+
+    return this;
+  };
+
+  ValidatedPromise.prototype.catch = function(err) {
+    this.promiseChain = this.promiseChain.catch(err);
+    return this;
+  };
+
+  ValidatedPromise.prototype.finally = function(next) {
+    this.promiseChain = this.promiseChain.finally(next);
+    return this;
+  };
+
+  ValidatedPromise.prototype.getPromise = function() {
+    return promiseChain;
+  };
+
+  return function(validator) {
+    return new ValidatedPromise(validator);
+  };
+});


### PR DESCRIPTION
Adds reverse federation to the send pane.
Process the address without blocking on the results of reverse federation (fixes #459).

Fixes #714.
