### PR TITLE
Remove symbol constraint from password strength computation so we get back to 8 character minimum.

### DIFF
--- a/app/scripts/controllers/password-controller.js
+++ b/app/scripts/controllers/password-controller.js
@@ -14,6 +14,7 @@ sc.controller('PasswordCtrl', function($scope, passwordStrengthComputations, bad
   delete passwordStrengthComputations.aspects.duplicates;
   delete passwordStrengthComputations.aspects.consecutive;
   delete passwordStrengthComputations.aspects.dictionary;
+  delete passwordStrengthComputations.aspects.symbols;
 
   // Enforce 8 character minimum.
   passwordStrengthComputations.aspects.minLength = {


### PR DESCRIPTION
Fixes #780 
