### PR TITLE
Reward copy refactor

### DIFF
--- a/app/scripts/controllers/email-reward-controller.js
+++ b/app/scripts/controllers/email-reward-controller.js
@@ -7,33 +7,28 @@ sc.controller('EmailRewardCtrl', function ($scope, $rootScope, session) {
     rewardType: 2,
     status: 'incomplete',
     innerTitle: 'Set up password recovery',
-    getCopy: function(type) {
+    getCopy: function() {
       switch ($scope.reward.status) {
         case 'unverified':
           // User put in email but hasn't put in recovery code
-          var copy = {
+          return {
             title: 'Set up password recovery!',
             subtitle: 'Enter your recovery code to complete'
           };
-          break;
         case 'needs_fbauth':
         case 'sending':
         case 'sent':
           // User needs to fb auth before they can get their stellars (when they're done, still show this message)
-          var copy = {
+          return {
             title: 'Password recovery activated',
             subtitle: 'Log in with Facebook to receive stellars'
-          }
-          break;
+          };
         default:
-          var copy = {
+          return {
             title: 'Set up password recovery!',
             subtitle: 'Verify your email'
-          }
-          break;
+          };
       }
-
-      return copy[type];
     },
     updateReward: function (status) {
       $scope.reward.status = status;

--- a/app/scripts/controllers/facebook-reward-controller.js
+++ b/app/scripts/controllers/facebook-reward-controller.js
@@ -5,38 +5,46 @@ var sc = angular.module('stellarClient');
 sc.controller('FacebookRewardCtrl', function ($rootScope, $scope, $http, session) {
   $scope.reward = {
     rewardType: 1,
-    title: 'Receive stellars on us!',
-    getSubtitle: function () {
-      if (!$scope.data) {
-        return;
-      }
-      if ($scope.data.inviteCode && !$scope.data.hasClaimedInviteCode) {
-        return "Enter your invite code now to receive stellars!";
-      } else if ($scope.data.inviteCode && $scope.data.hasClaimedInviteCode) {
-        return "Thanks to " + $scope.data.inviterUsername + " you will receive stellars once you connect to Facebook.";
-      } else {
-        return 'Log in with Facebook'
+    status: 'incomplete',
+    innerTitle: 'Receive stellars',
+    getCopy: function() {
+      switch ($scope.rewards.status) {
+        case 'sent':
+          return {
+            title: 'You connected your Facebook!',
+            subtitle: getInviteSubtitle()
+          };
+        case 'reward_error':
+        case 'reward_queued':
+          return {
+            title: "You connected your Facebook!",
+            subtitle: "You are on the waiting list! You will get your stellars soon."
+          };
+        case 'sending':
+          return {
+            title: "You connected your Facebook!",
+            subtitle: "...you should be receiving your reward shortly!"
+          };
+        case 'ineligible':
+          return {
+            title: "Your Facebook account is not eligible.",
+            subtitle: "Please check back for other ways to participate soon."
+          };
+        case 'fake':
+          // TODO: their account is fake
+        case 'incomplete':
+          /* falls through */
+        default:
+          return {
+            title: 'Receive stellars on us!',
+            subtitle: getInviteSubtitle()
+          };
       }
     },
-    innerTitle: 'Receive stellars',
-    status: 'incomplete',
     error: null,
     updateReward: function (status) {
       $scope.reward.status = status;
       switch (status) {
-        case 'sent':
-          $scope.reward.title = 'You connected your Facebook!';
-          $scope.reward.subtitle = null;
-          break;
-        case 'reward_error':
-        case 'reward_queued':
-          $scope.reward.title = "You connected your Facebook!";
-          $scope.reward.subtitle = "You are on the waiting list! You will get your stellars soon.";
-          break;
-        case 'sending':
-          $scope.reward.title = "You connected your Facebook!";
-          $scope.reward.subtitle = "...you should be receiving your reward shortly!";
-          break;
         case 'unverified':
           $scope.reward.error = {};
           $scope.reward.error.template = "templates/facebook-verify-error.html";
@@ -48,8 +56,6 @@ sc.controller('FacebookRewardCtrl', function ($rootScope, $scope, $http, session
           break;
         case 'ineligible':
           $scope.reward.error = {};
-          $scope.reward.title = "Your Facebook account is not eligible.";
-          $scope.reward.subtitle = "Please check back for other ways to participate soon.";
           $scope.reward.error.info = "Our spam detection checks say your Facebook account isn't eligible. If you are a legitimate user, we apologize and are improving our detection algorithms. And we will release new ways to grab stellars soon, so please check back.";
           $scope.reward.error.panel = "Sorry, your Facebook account isn't eligible."
           $scope.reward.error.action = null;
@@ -71,8 +77,19 @@ sc.controller('FacebookRewardCtrl', function ($rootScope, $scope, $http, session
   };
   // add this reward to the parent scope's reward array
   $scope.rewards[$scope.reward.rewardType] = $scope.reward;
-
   $scope.reward.template = 'templates/facebook-button.html';
+
+  var getInviteSubtitle = function() {
+    if ($scope.data) {
+      if ($scope.data.inviteCode && !$scope.data.hasClaimedInviteCode) {
+        return "Enter your invite code now to receive stellars!";
+      } else if ($scope.data.inviteCode && $scope.data.hasClaimedInviteCode) {
+        return "Thanks to " + $scope.data.inviterUsername + " you will receive stellars once you connect to Facebook.";
+      }
+    }
+
+    return 'Log in with Facebook';
+  };
 
   $scope.facebookLogin = function () {
     $scope.loading = true;

--- a/app/scripts/controllers/registration-reward-controller.js
+++ b/app/scripts/controllers/registration-reward-controller.js
@@ -5,10 +5,14 @@ var sc = angular.module('stellarClient');
 sc.controller('RegistrationRewardCtrl', function ($scope, session) {
   $scope.reward = {
     rewardType: 0,
-    title: 'Create a new wallet!',
-    subtitle: 'Complete registration',
+    status: 'sent',
     innerTitle: 'Create a new wallet',
-    status: 'sent'
+    getCopy: function() {
+      return {
+        title: 'Create a new wallet!',
+        subtitle: 'Complete registration',
+      };
+    }
   };
 
   $scope.rewards[$scope.reward.rewardType] = $scope.reward;

--- a/app/scripts/controllers/send-reward-controller.js
+++ b/app/scripts/controllers/send-reward-controller.js
@@ -5,28 +5,24 @@ var sc = angular.module('stellarClient');
 sc.controller('SendRewardCtrl', function ($rootScope, $scope, $http, stNetwork, session, TutorialHelper) {
   $scope.reward = {
     rewardType: 3,
-    innerTitle: 'Learn to send stellars',
     status: 'incomplete',
-    getCopy: function(type) {
+    innerTitle: 'Learn to send stellars',
+    getCopy: function() {
       switch ($scope.reward.status) {
         case 'needs_fbauth':
         case 'sending':
         case 'sent':
           // User needs to fb auth before they can get their stellars (when they're done, still show this message)
-          var copy = {
+          return {
             title: 'Sent!',
             subtitle: 'Log in with Facebook to receive stellars'
-          }
-          break;
+          };
         default:
-          var copy = {
+          return {
             title: 'Send stellars!',
             subtitle: 'Learn to send'
-          }
-          break;
+          };
       }
-
-      return copy[type];
     },
     updateReward: function (status) {
       $scope.reward.status = status;

--- a/app/templates/reward-list.html
+++ b/app/templates/reward-list.html
@@ -5,8 +5,8 @@
             <span class="reward-step" ng-show="reward.rewardType == 1 && reward.status != 'sent'">
             	<span class="step-label">Next Step</span>
             </span>
-            <span class="reward-title">{{ reward.error.panel || reward.title || reward.getCopy('title')}}</span>
-            <span class="subtitle">{{reward.subtitle || reward.getSubtitle() || reward.getCopy('subtitle')}}</span>
+            <span class="reward-title">{{reward.error.panel || reward.getCopy().title}}</span>
+            <span class="subtitle">{{reward.getCopy().subtitle}}</span>
         </div>
     </li>
 </ul>


### PR DESCRIPTION
I recently made changes to the copy in the reward pane: https://github.com/stellar/stellar-client/pull/775

This new PR refactors the stuff from PR775 and unifies the getters for the copy in the reward pane.

Main things:
- Templates now access a unified `$scope.reward.getCopy()` to get either the title or the subtitle. Before, it was direct access to scope variables set every time it received an update from fbgive.
