### PR TITLE
The destination tag must be a number

### DIFF
--- a/app/scripts/controllers/send-form-controller.js
+++ b/app/scripts/controllers/send-form-controller.js
@@ -89,7 +89,7 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, S
         // parse the dt parameter if it has one
         var destinationTag = webutil.getDestTagFromAddress(input);
         if (destinationTag) {
-            $scope.send.destination.destinationTag = destinationTag;
+            $scope.send.destination.destinationTag = Number(destinationTag);
         }
 
         whileValid(function() {


### PR DESCRIPTION
`stellar-lib` was throws an error when the destination tag is a string instead of a number.

Fixes #804.
