### PR TITLE
Fix trading quirks

### DIFF
--- a/app/scripts/controllers/trading-controller.js
+++ b/app/scripts/controllers/trading-controller.js
@@ -46,7 +46,7 @@ sc.controller('TradingCtrl', function($scope, session, singletonPromise, Trading
     if (_.isEmpty($scope.baseCurrency)) { return false; }
     if (_.isEmpty($scope.counterCurrency)) { return false; }
 
-    if ($scope.baseCurrency === $scope.counterCurrency) { return false; }
+    if (_.isEqual($scope.baseCurrency, $scope.counterCurrency)) { return false; }
 
     return true;
   };


### PR DESCRIPTION
Multiply with BigNumber to prevent errors.
Clear the order book for invalid currency pairs (same fix I added to /trade to clear the orders table when the pair is invalid).
Delete the currency's issuer if it is undefined/falsy (`_.isEqual({currency: 'STR'}, {currency: 'STR', issuer: undefined}) // => false`)
Deep compare currencies to determine if they have changed.
