### PR TITLE
Allow Users to Specify Idle Logout Timeout

### DIFF
--- a/app/scripts/controllers/settings-controller.js
+++ b/app/scripts/controllers/settings-controller.js
@@ -132,20 +132,20 @@ sc.controller('SettingsCtrl', function($scope, $http, $state, session, singleton
       .tooltip('show');
   }
 
-  $scope.idleTimeout = getIdleTimeoutAsMinutes();
+  $scope.idleTimeout = getIdleTimeout();
   $scope.timeoutOptions = [15, 30, 60, 120];
 
   $scope.setIdleTimeout = function (minutes) {
-    session.setIdleTimeout(minutes);
+    wallet.set('mainData', 'idleLogoutTime', minutes * 60 * 1000); // convert to ms
+    session.syncWallet('update');
   };
 
   $scope.resetIdleTimeout = function () {
-    $scope.idleTimeout = getIdleTimeoutAsMinutes();
+    $scope.idleTimeout = getIdleTimeout();
   };
 
-  // get idle timeout and convert to minutes
-  function getIdleTimeoutAsMinutes() {
-    return session.getIdleTimeout() / (60 * 1000);
+  function getIdleTimeout() {
+    return session.getIdleTimeout() / (60 * 1000); // convert to minutes
   }
 
   getSettings()

--- a/app/scripts/services/session.js
+++ b/app/scripts/services/session.js
@@ -33,28 +33,13 @@ sc.service('session', function($rootScope, $http, $timeout, $window, StellarNetw
 
   }, 1000, true);
 
-  function minutesToMS(minutes) {
-    var milliseconds = minutes * 60 * 1000;
-      if (isNaN(milliseconds)) {
-        milliseconds = 0;
-      }
-
-      return milliseconds;
-  }
-
   Session.prototype.getIdleTimeout = function() {
-    var defaultTimeout = Options.DEFAULT_IDLE_LOGOUT_TIMEOUT || 15 * 60 * 1000,
-      userDefinedTimeout = $window.localStorage[Options.USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY];
-
-      return userDefinedTimeout && !isNaN(userDefinedTimeout) ? userDefinedTimeout : defaultTimeout;
+    var self = this, wallet = self.get('wallet');
+    return wallet.get('mainData', 'idleLogoutTime', Options.DEFAULT_IDLE_LOGOUT_TIMEOUT || 15 * 60 * 1000);
   };
 
-  Session.prototype.setIdleTimeout = function(minutes) {
-    var self = this,
-      timeout = minutesToMS(minutes);
-      if (timeout > 0) {
-          $window.localStorage[Options.USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY] = timeout;
-      }
+  Session.prototype.setIdleTimeout = function() {
+    var self = this;
 
     this.idleTimeout = $timeout(function() {
       self.logout(true);

--- a/app/scripts/utilities/wallet.js
+++ b/app/scripts/utilities/wallet.js
@@ -277,7 +277,7 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, $window, i
     var encryptedWalletKey = Wallet.encryptData(this.key, loginWalletKey);
 
     catchAndSwallowSecurityErrors(function() {
-      ipCookie("localWalletKey", loginWalletKey, {expires:getExpires(), expirationUnit:'seconds', secure: Options.COOKIE_SECURE});
+      ipCookie("localWalletKey", loginWalletKey, {expires:getExpires(self), expirationUnit:'seconds', secure: Options.COOKIE_SECURE});
       localStorage.encryptedWalletKey = encryptedWalletKey;
       localStorage.wallet             = Wallet.encryptData(self, sjcl.codec.hex.toBits(self.key));
       sessionStorage.wallet           = JSON.stringify(self);
@@ -286,18 +286,16 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, $window, i
 
 
   Wallet.prototype.bumpLocalTimeout = function() {
+    var self = this;
+
     //TODO: push the cookie timeout forward
     catchAndSwallowSecurityErrors(function() {
-      ipCookie("localWalletKey", ipCookie("localWalletKey"), {expires:getExpires(), expirationUnit:'seconds', secure: Options.COOKIE_SECURE});
+      ipCookie("localWalletKey", ipCookie("localWalletKey"), {expires: getExpires(self), expirationUnit: 'seconds', secure: Options.COOKIE_SECURE});
     });
   };
 
-  // gets the expires value for ipCookie using either the user defined idle timeout or the default value
-  function getExpires() {
-    var userDefinedIdleTimeout = $window.location[Options.USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY],
-      defaultIdleTimeout = Options.DEFAULT_IDLE_LOGOUT_TIMEOUT;
-
-    return userDefinedIdleTimeout ? userDefinedIdleTimeout / 1000 : defaultIdleTimeout / 1000;
+  function getExpires(wallet) {
+      return wallet.get('mainData', 'idleLogoutTime', Options.DEFAULT_IDLE_LOGOUT_TIMEOUT) / 1000;
   }
 
   /**

--- a/app/states/settings.html
+++ b/app/states/settings.html
@@ -252,7 +252,7 @@
                             <div class="col-xs-10">
                                 <div class="row">
                                     <div class="col-md-5 col-xs-12">
-                                        <select class="form-control"  ng-model="idleTimeout" ng-options="o as o for o in timeoutOptions"></select>
+                                        <select class="form-control"  ng-model="idleTimeout" ng-options="time for time in timeoutOptions"></select>
                                     </div>
                                 </div>
                                 <div class="row">

--- a/config/dev.js
+++ b/config/dev.js
@@ -25,7 +25,6 @@ var Options = {
     // intended for developers, be careful about using this in a real setting.
     PERSISTENT_SESSION : true,
     DEFAULT_IDLE_LOGOUT_TIMEOUT : 60 * 60 * 1000, //an hour,
-    USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY: 'idleLogoutTimeout',
     COOKIE_SECURE: false,
 
 

--- a/config/prd.js
+++ b/config/prd.js
@@ -23,7 +23,6 @@ var Options = {
 
     PERSISTENT_SESSION : false,
     DEFAULT_IDLE_LOGOUT_TIMEOUT : 30 * 60 * 1000, //15 minutes
-    USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY: 'idleLogoutTimeout',
     COOKIE_SECURE: true,
 
     REPORT_ERRORS : true,

--- a/config/stg.js
+++ b/config/stg.js
@@ -25,7 +25,6 @@ var Options = {
     // intended for developers, be careful about using this in a real setting.
     PERSISTENT_SESSION : false,
     DEFAULT_IDLE_LOGOUT_TIMEOUT : 15 * 60 * 1000, //15 minutes
-    USER_DEFINED_IDLE_LOGOUT_TIMEOUT_KEY: 'idleLogoutTimeout',
 
     REPORT_ERRORS : true,
     SENTRY_DSN : "https://4574695240794dc090caaa3f2d02fd6c@app.getsentry.com/27687",


### PR DESCRIPTION
This branch implements allowing users to specify the number of minutes of idle time before being automatically logged out. The specified value is saved to local storage and the local storage key is defined as an exported option in the configuration files for each environment.

The should resolve issue https://github.com/stellar/stellar-client/issues/583.

As an aside, there's a bit of a code smell in that the session service is responsible for managing these values, but Wallet needs them in order to set the expire value for ipCookie. Having Wallet depend on session would, of course, create a circular dependency, so no immediately obvious fix presented itself.
