### PR TITLE
Set destination tag from dt parameter in action-send url

### DIFF
--- a/app/scripts/controllers/send-form-controller.js
+++ b/app/scripts/controllers/send-form-controller.js
@@ -19,7 +19,7 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, S
         if (params.dt) {
             // use a short timeout to allow digest from watchers of above values
             // to run first and call $scope.resetDestinationDependencies() (which overwrites values below)
-            setTimeout(function () {
+            $timeout(function () {
                 $scope.send.showDestinationTag = true;
                 $scope.send.destination.destinationTag =  Number(params.dt);
             }, 100);


### PR DESCRIPTION
- Use a small timeout before setting $scope.send.destinationTag (boolean)
  and $scope.send.destination.destinationTag (value)
- Before, the $scope.watch for the other values (recipient, amount, currency) were firing
  after these values were set, calling $scope.resetDestinationDependencies which would overwrite
  the destination tag variables. This allows the digest to happen and the watchers to run before
  setting the destination tag variables
- TODO: this is hacky and not optimal. A more correct solution would be to refactor the flow
  of the send pane to avoid resetting the destination tag each time if unneeded
  Fixes #862
