### PR TITLE
Explicitly disable browser native spell check in send pane

### DIFF
--- a/app/templates/send-form.html
+++ b/app/templates/send-form.html
@@ -3,7 +3,7 @@
         <div class="form-group send-address">
             <label for="recipient" class="col-md-2">SEND TO</label>
             <div class="col-md-6 input-icon-wrapper">
-                <input id="recipient" name="recipient" type="text" class="form-control" ng-model="sendFormModel.recipient"/>
+                <input id="recipient" name="recipient" type="text" class="form-control" spellcheck="false" ng-model="sendFormModel.recipient"/>
                 <i class="glyphicon glyphicon-globe"></i>
             </div>
             <div class="col-md-4 tip">Stellar name or address.</div>


### PR DESCRIPTION
![screen shot 2014-09-26 at 11 08 29 am](https://cloud.githubusercontent.com/assets/5728307/4425367/00401882-45a9-11e4-8d57-fa6b14f998ca.png)

Sometimes, spellcheck shows up in the `SEND TO` section of the send pane. This can be confusing to some users since an address can be valid but there is a red line showing underneath signifying something was wrong.

This PR uses the new HTML5 spellcheck attribute. Read more about it's history and compatibility here: https://blog.whatwg.org/the-road-to-html-5-spellchecking
