### PR TITLE
Keep federated dt

### DIFF
--- a/app/scripts/controllers/send-form-controller.js
+++ b/app/scripts/controllers/send-form-controller.js
@@ -351,7 +351,12 @@ sc.controller('SendFormController', function($rootScope, $scope, $timeout, $q, S
     }
 
     function showAddressFound(address) {
-        Util.showTooltip($('#recipient'), "wallet address found: " + address, "info", "top");
+        var displayAddress = address;
+        if($scope.send.destination.destinationTag) {
+            displayAddress += '?dt=' + $scope.send.destination.destinationTag;
+        }
+
+        Util.showTooltip($('#recipient'), "wallet address found: " + displayAddress, "info", "top");
     }
 
     function showUserFound(username) {


### PR DESCRIPTION
Set the destinationTag with the federated results.
Show the dt in the address found poptip.

Fixes #921.
