### PR TITLE
Set BigNumber to not use exponents

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -181,3 +181,8 @@ stellarClient.run(function($rootScope, $state, $timeout, ipCookie, session, Flas
     FlashMessages.dismissAll();
   });
 });
+
+stellarClient.config(function() {
+  // Configure BigNumber to never return exponential notation
+  BigNumber.config({ EXPONENTIAL_AT : 1e+9 });
+});


### PR DESCRIPTION
This makes `BigNumber` output the full plain number (with no exponents). Taken from http://mikemcl.github.io/bignumber.js/#exponential-at

`1844674407370955e4` is now  `18446744073709550000`
`5.4210108624e-10` is now `0.00000000054210108624`

https://github.com/stellar/stellar-client/issues/904
