### PR TITLE
Implements one-click highlighting of Stellar address per #557

### DIFF
--- a/app/scripts/directives/directives.js
+++ b/app/scripts/directives/directives.js
@@ -9,13 +9,51 @@ var module = angular.module('stellarClient');
 * A directive that includes the toggle template.
 */
 module.directive('stToggle', function() {
-
     return {
         templateUrl: 'templates/toggle.html',
         scope: {
             ctrl: '='
         }
     };
+});
+
+
+/**
+ * A directive which highlights the contents of the element having
+ * the specified target-id or the first element of the selection.
+ *
+ * @example
+ *    <div class="col-sm-6 receive-address" st-select-on-click target-id="currentAddress">
+ *        <i class="glyphicon glyphicon-globe"></i>
+ *        <span class="address" id="currentAddress">{{currentAddress()}}</span>
+ *    </div>
+ */
+module.directive('stSelectOnClick', function ($window) {
+  return{
+    restrict: 'AE',
+    scope: {
+      targetId: '@targetId'
+    },
+    link: function (scope, element) {
+      element.on('click', function () {
+
+        // get the user's selection, create a range and set the target element whose contents will be highlighted
+        var selection = $window.getSelection(),
+          range = document.createRange(),
+          target = scope.targetId ? document.getElementById(scope.targetId) : element[0];
+
+        // if no target element can be found, throw
+        if (!target) {
+          throw new Error("No target found.");
+        }
+
+        // otherwise, select the contents of the target element and add the range to the selection
+        range.selectNodeContents(target);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      });
+    }
+  }
 });
 
 

--- a/app/templates/receive.html
+++ b/app/templates/receive.html
@@ -22,9 +22,9 @@
         </div>
         <div class="row form-group address-row" ng-show="showAddress">
             <label for="receive_address" class="col-sm-3 address-title">YOUR STELLAR ADDRESS</label>
-            <div class="col-sm-6 receive-address">
+            <div class="col-sm-6 receive-address" st-select-on-click target-id="currentAddress">
                 <i class="glyphicon glyphicon-globe"></i>
-                <span class="address">{{currentAddress()}}</span>
+                <span class="address" id="currentAddress">{{currentAddress()}}</span>
             </div>
         </div>
     </form>


### PR DESCRIPTION
This should address #557. The directive allows one to highlight the contents of a specified element by ID via the target-id attribute. Otherwise, it will highlight all of its contents.
