### PR TITLE
Made sure to cast number to string before passing to BigNumber

### DIFF
--- a/app/scripts/filters/filters.js
+++ b/app/scripts/filters/filters.js
@@ -29,6 +29,7 @@ module.filter('amountToHuman', function () {
 module.filter('roundAmount', function () {
     return function (amount, currency) {
         try {
+            amount = amount.toString();
             new BigNumber(amount);
         } catch (e) {
             return 0;


### PR DESCRIPTION
Fixes https://github.com/stellar/stellar-client/issues/955

Here is an explanation of why the problem happened:

`dashboard.html` and `balances.html` both use a different data source for the balances (yeah, it's weird, a refactor is needed). `balances.html` gets number strings (as usual) but `dashboard.html` gets an actual JS `Number` object.

BigNumber docs say:

```
Values of type number with more than 15 significant digits are considered invalid as 
calling toString or valueOf on such numbers may not result in the intended value.
```

The Ripple docs (which is currently relevant for most parts of Stellar) says:

```
the legal mantissa range is 10^15 to 10^16 -1.
```

Without the filter, it looks like this:
![screen shot 2014-10-06 at 1 35 08 pm](https://cloud.githubusercontent.com/assets/5728307/4533174/02d77f38-4d9a-11e4-9796-78c28b0871c0.png)

It has 16 significant figures. We got [un]lucky here. BigNumber gets sad when a javascript `Number` has more than 15 digits.

**TL;DR; Make sure datasources return strings for balances**
