### PR TITLE
Prevent adding multiple transaction listener

### DIFF
--- a/app/scripts/controllers/transaction-history.js
+++ b/app/scripts/controllers/transaction-history.js
@@ -40,8 +40,7 @@ sc.controller('TransactionHistoryCtrl', function($scope, transactionHistory) {
     currentPage: 1
   };
 
-  transactionHistory.init()
-    .then(updateTransactionPage);
+  updateTransactionPage();
 
   $scope.transactionGrid = {
     data: 'transactionPage',


### PR DESCRIPTION
Multiple transactions were showing up in the history, because each time the app navigated to the dashboard another transaction listener was added.
- Remove `transactionHistory.init()` in favor of `transactionHistory.getPage()` ensuring that the service is initialized before continuing.
- Wait for `StellarNetwork.ensureConnection()` before initializing instead of waiting for an event.
- Remove `cleanupListeners()`. Since `init()` is now guaranteed to only run once and we are no longer initializing after every reconnect, we never have to remove the transaction listener.

Fixes #817.
