### PR TITLE
Catch BigNumber errors in roundedAmount filter

### DIFF
--- a/app/scripts/filters/filters.js
+++ b/app/scripts/filters/filters.js
@@ -434,8 +434,11 @@ module.filter('currencyName', function() {
 
 module.filter('roundedAmount', function() {
     return function(amount, precision) {
-        if(amount) {
-             return new BigNumber(amount).round(precision).toString();
+        try {
+            amount = amount.toString();
+            return new BigNumber(amount).round(precision).toString();
+        } catch (e) {
+            return 0;
         }
     };
 });


### PR DESCRIPTION
This change structures the code like how the `roundAmount` filter does.

Part 1 of https://github.com/stellar/stellar-client/issues/977

> ## Part 1: Catch BigNumber errors
> 
> ![screen_shot_2014-10-08_at_2_47_10_pm](https://cloud.githubusercontent.com/assets/5728307/4568107/23694ad0-4f37-11e4-8376-e67772bb370e.png)
