### PR TITLE
fetch username for inflation dest

### DIFF
--- a/app/scripts/controllers/settings-inflation-dest-controller.js
+++ b/app/scripts/controllers/settings-inflation-dest-controller.js
@@ -7,7 +7,9 @@ var sc = angular.module('stellarClient');
 sc.controller('SettingsInflationDestCtrl', function($scope, $q, session, singletonPromise, contacts) {
   $scope.reset = function () {
     $scope.inflationDest = $scope.account.InflationDest;
-    contacts.fetchContactByAddress($scope.inflationDest);
+    if ($scope.inflationDest) {
+        contacts.fetchContactByAddress($scope.inflationDest);
+    }
     $scope.newInflationDest = '';
     $scope.changing = false;
   };


### PR DESCRIPTION
This targets #963

I verified at a quick glance in services/contacts that the fetchContactByAddress method will only make a request if the contact isn't already stored in localStorage.

I ran this quickly on my dev to test. To reproduce, your inflation destination should be something not already present in, say, the transaction history. Otherwise, the work done in those pages to translate addresses will appear to have solved this issue for us. I made sure I had an address showing up for the inflation destination, then added this line.

Not sure what kind of testing should go along with a change like this, if any. Worst case, I'm hopefully helping someone else finish this!
