### PR TITLE
Don't process action links until logged in

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -137,10 +137,12 @@ stellarClient.run(function($rootScope, $timeout, StellarNetwork, ActionLink){
   });
 
   $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){
-    StellarNetwork.ensureConnection().then(function() {
-      // HACK: Timeout required to allow templates' controllers initialize and start listening.
-      $timeout(ActionLink.process, 0);
-    });
+    if(toState.authenticate) {
+      StellarNetwork.ensureConnection().then(function() {
+        // HACK: Timeout required to allow templates' controllers initialize and start listening.
+        $timeout(ActionLink.process, 0);
+      });
+    }
   });
 });
 


### PR DESCRIPTION
Only process action links once the user is logged in.

Fixes #751.
