### PR TITLE
Fix action link alert from showing up when it wasn't supposed to

### DIFF
--- a/app/scripts/controllers/add-gateway-controller.js
+++ b/app/scripts/controllers/add-gateway-controller.js
@@ -60,5 +60,9 @@ sc.controller('AddGatewayCtrl', function($scope, $q, session, singletonPromise, 
     $scope.resetSearch();
   };
 
+  $scope.actionLinkAlertActive = function() {
+    return $scope.fromActionLink && $scope.searchStatus !== 'already_added';
+  };
+
   $scope.resetSearch();
 });

--- a/app/templates/manage-currencies.html
+++ b/app/templates/manage-currencies.html
@@ -6,7 +6,7 @@
 
     <div class="gateway-form" ng-controller="AddGatewayCtrl">
         <div class="title">Manage currencies</div>
-        <alert type="info" ng-show="fromActionLink && searchStatus !== 'already_added'" dismissible="true">
+        <alert type="info" ng-show="actionLinkAlertActive()" dismissible="true">
             You just clicked on a link that automatically lets you add a gateway. Complete this action by clicking "Trust {{foundGateway.domain}}" if you want to trust this gateway. Find out more <a href="https://www.stellar.org/learn/#Gateways_trust_and_credit">about trust</a>.
         </alert>
         <p>Add a gateway to send and receive in a new currency with your account. Find out <a href="https://github.com/stellar/docs/blob/master/docs/Adding-Multiple-Currencies.md" target="_blank">more</a>.


### PR DESCRIPTION
Unfortunately, ng-show and ng-hide don't work together nicely.
#1031
