### PR TITLE
Fixed misalignment with sent/receive tooltip

### DIFF
--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -172,7 +172,7 @@
     white-space: nowrap;
 
     .client-section {
-      margin-top: -36px;
+      margin-top: -24px;
       text-align: center;
       position: relative;
       height: 0;


### PR DESCRIPTION
Before:
![screen shot 2014-10-27 at 1 21 11 pm](https://cloud.githubusercontent.com/assets/5728307/4799060/3b2e32ac-5e19-11e4-8f0e-f7a339a0bec5.png)

This PR aligns the height (there is a little arrow on the `view all balances`) and also fixes the centering issue on both Firefox and Safari.

Fictional: This PR also solves a big chunk of the US debt.

https://github.com/stellar/stellar-client/issues/990
