### PR TITLE
Setup recovery blob before verifying email

### DIFF
--- a/app/scripts/controllers/verify-email-controller.js
+++ b/app/scripts/controllers/verify-email-controller.js
@@ -86,9 +86,9 @@ sc.controller('VerifyEmailCtrl', function ($scope, $rootScope, $http, $state, $a
       if (response.data && response.data.field === 'recovery_code') {
         $scope.errors.push('Invalid recovery code.');
       }
-      return $q.reject();
     }
-    
+
+    return $q.reject();
   }
 
   $scope.clear = function() {


### PR DESCRIPTION
This PR represents the client-side changes to support ix-340;  namely, it moves the generation and storage of the recovery blob to before we make the verify email call (which burns the client side portion of the recovery token that is stored in fbgive).

With this PR, the wallet server can be in a failed state and a user will no longer get a false-positive that they have enabled password recovery. 
