### PR TITLE
Use stellar-lib with reconnect ledger timeout fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "ng-grid": "deckar01/ng-grid",
     "angular-cookie": "~4.0.2",
     "ng-clip": "*",
-    "stellar-lib": "0.10.0",
+    "stellar-lib": "0.10.1",
     "zeroclipboard": "*",
     "bignumber.js": "~1.4.1",
     "angular-re-captcha": "0.0.3",


### PR DESCRIPTION
Use the latest version of stellar-lib, which contains a fix for the ledger timeout when reconnecting.
Resets the timeout after a reconnect and increase the timeout threshold to 60 seconds.
