### PR TITLE
Use the latest version of npm for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 install:
+  - npm install -g npm@2.1.7
   - npm install
   - npm install -g bower
   - bower install


### PR DESCRIPTION
Trying the suggestion from http://stackoverflow.com/questions/26474640/why-travisci-builds-fails-during-npm-install-due-to-file-lock to fix #1070.
