### PR TITLE
add icon for trade nav

### DIFF
--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -21,7 +21,7 @@
                         <span>invite ({{ getInvitesLeft() }})</span>
                     </a>
                 </li>
-                <li ng-show="showTradingLink()"><a href="#/trading">trade</a></li>
+                <li ng-show="showTradingLink()"><a href="#/trading"><span class="glyphicon glyphicon-transfer"></span>trade</a></li>
                 <li><a href="#/settings"><span class="glyphicon glyphicon-cog"></span>{{ username }}</a></li>
                 <li><a href="#/logout" ui-sref="logout"><span class="glyphicon glyphicon-log-out"></span>LOG OUT</a></li>
             </ul>


### PR DESCRIPTION
fix #962 with bootstrap icons, probably a temp fix until the modular client is redesigned with potentially custom icons.

![image](https://cloud.githubusercontent.com/assets/51415/5003100/f12461d0-69bd-11e4-909b-0a2e651a592a.png)
