### PR TITLE
Fix trade history

### DIFF
--- a/app/scripts/services/trade-history-service.js
+++ b/app/scripts/services/trade-history-service.js
@@ -230,6 +230,21 @@ sc.service('TradeHistory', function($rootScope, TransactionHistory, Trading, ses
       }
     });
 
+    // Consolidate multiple changes of the same currency.
+    balanceChanges = _(balanceChanges)
+      .groupBy(function(balanceChange) {
+        return [balanceChange.currency, balanceChange.issuer];
+      })
+      .map(function(currencyChanges) {
+        var currencyChange = _.pick(currencyChanges[0], ['currency', 'issuer']);
+        currencyChange.value = currencyChanges.reduce(function(totalValue, nextChange) {
+          return totalValue.plus(nextChange.value);
+        }, new BigNumber(0));
+
+        return currencyChange;
+      })
+      .value();
+
     return balanceChanges;
   }
 


### PR DESCRIPTION
While testing I found 2 bugs in the trade history.
- AccountRoot type nodes are not guaranteed to have a FinalFields property.
- Balance changes resulting from trades that fill multiple offers were not being added together.

https://app.getsentry.com/gostellarorg/stellar-client/?query=Cannot+read+property+%27Account%27+of+undefined
