### PR TITLE
Add balance transfer to settings

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -180,6 +180,7 @@
 <script src="scripts/controllers/settings-totp-controller.js"></script>
 <script src="scripts/controllers/settings-recovery-controller.js"></script>
 <script src="scripts/controllers/settings-inflation-dest-controller.js"></script>
+<script src="scripts/controllers/settings-transfer-balance-controller.js"></script>
 <script src="scripts/controllers/trade-controller.js"></script>
 <script src="scripts/controllers/my-offers-list-item-controller.js"></script>
 <script src="scripts/controllers/trading-controller.js"></script>

--- a/app/scripts/controllers/app-controller.js
+++ b/app/scripts/controllers/app-controller.js
@@ -90,6 +90,12 @@ sc.controller('AppCtrl', function($scope, $rootScope, StellarNetwork, session, $
     }
 
     function handleAccountEntry(data) {
+        // Handle account entry after account merge.
+        if(data.Balance === '0') {
+            $rootScope.account = {};
+            return;
+        }
+
         $rootScope.account = data;
 
         // As per json wire format convention, real ledger entries are CamelCase,

--- a/app/scripts/controllers/settings-transfer-balance-controller.js
+++ b/app/scripts/controllers/settings-transfer-balance-controller.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/* jshint camelcase:false */
+
+var sc = angular.module('stellarClient');
+
+sc.controller('TransferBalanceCtrl', function($scope, $rootScope, $q, StellarNetwork, session, singletonPromise, contacts, Gateways) {
+  $scope.reset = function () {
+    $scope.transferDestination = '';
+    $scope.state = 'closed';
+  };
+
+  $scope.reset();
+
+  $scope.$on('settings-refresh', $scope.reset);
+
+  $scope.openForm = function () {
+    $scope.state = 'open';
+  };
+
+  $scope.confirmTransfer = function () {
+    $scope.state = 'confirm';
+  };
+
+  $scope.accountEmpty = function() {
+    return !$scope.account.Account;
+  };
+
+  $scope.transferBalance = singletonPromise(function() {
+    return getAddress($scope.transferDestination)
+      .then(function(address) {
+        var tx = $scope.mergeAccount(address);
+        var deferred = $q.defer();
+
+        tx.on('success', deferred.resolve);
+        tx.on('error', deferred.reject);
+
+        return deferred.promise.catch(function(err) {
+          return $q.reject(err.engine_result_message);
+        });
+      })
+      .then(function (result) {
+        Gateways.markAllRemoved();
+        $scope.reset();
+      })
+      .catch(function(err) {
+        $scope.state = 'open';
+
+        // Construct an error for handleServerError.
+        $scope.handleServerError($('#account-merge-input'))({
+          data: {
+            status: 'fail',
+            message: err || 'Server error'
+          }
+        });
+      });
+  });
+
+  function getAddress(input) {
+    if(stellar.UInt160.is_valid(input)) {
+      // The input is an address.
+      return $q.when(input);
+    } else {
+      return contacts.fetchContactByEmail(input)
+        .then(function(result) {
+          // Return the federated address.
+          return result.destination_address;
+        })
+        .catch(function(err) {
+          return $q.reject(err.engine_result_message);
+        });
+    }
+  }
+
+  $scope.mergeAccount = function(destinationAddress) {
+    var tx = StellarNetwork.remote.transaction();
+    tx.accountMerge($scope.account.Account, destinationAddress);
+
+    tx.submit();
+
+    return tx;
+  };
+});

--- a/app/scripts/services/gateways-service.js
+++ b/app/scripts/services/gateways-service.js
@@ -99,6 +99,13 @@ sc.service('Gateways', function($q, $analytics, session, StellarNetwork, rpStell
     });
   }
 
+  Gateways.markAllRemoved = function() {
+    var mainData = session.get('wallet').mainData;
+    mainData.gateways = {};
+
+    return session.syncWallet('update');
+  };
+
   function addGateway(gateway) {
     return $q.all(gateway.currencies.map(function (currency) {
       return trustCurrency(currency, '9223372036854775806');

--- a/app/states/settings.html
+++ b/app/states/settings.html
@@ -302,6 +302,56 @@
                         </div>
                     </div>
                 </div>
+                <div class="row" ng-controller="TransferBalanceCtrl">
+                    <div class="settings-label col-md-3 col-xs-6">TRANSFER BALANCE</div>
+                    <div class="settings-control col-md-9 col-xs-6">
+                        <div class="row">
+                            <div class="icon-col col-xs-1">
+                                <span class="glyphicon glyphicon-trash"/>
+                            </div>
+                            <div ng-show="accountEmpty()" class="col-xs-10">
+                                Your account is empty.
+                            </div>
+                            <div ng-hide="accountEmpty()">
+                                <div ng-show="state === 'closed'">
+                                    <div class="col-xs-10">
+                                        <a href="" ng-click="openForm()">Transfer balance to another account</a>
+                                    </div>
+                                </div>
+                                <div class="col-xs-10" ng-show="state === 'open'">
+                                    <div class="row">
+                                        <div class="col-md-5 col-xs-12">
+                                            <input id="account-merge-input" data-toggle="tooltip" placeholder="Destination Account" type="text" class="form-control" ng-model="transferDestination"></input>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-4 col-xs-12 col-md-push-1">
+                                            <button class="btn btn-default stellar-button settings-confirm-button" ng-click="confirmTransfer()">Transfer Balance</button>
+                                        </div>
+                                        <div class="settings-cancel-button col-md-1 col-xs-1 col-md-pull-4">
+                                            <a href="" ng-click="reset()">Cancel</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-10" ng-show="state === 'confirm'">
+                                    <div class="row">
+                                        <div class="col-md-5 col-xs-12">
+                                            Are you sure you want to transfer your balance to {{ transferDestination }}?
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-4 col-xs-12 col-md-push-1">
+                                            <button class="btn btn-default stellar-button settings-confirm-button" ng-click="transferBalance()">{{ transferBalance.isLoading() ? "Loading..." : "Confirm" }}</button>
+                                        </div>
+                                        <div class="settings-cancel-button col-md-1 col-xs-1 col-md-pull-4">
+                                            <a href="" ng-click="reset()">Cancel</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/app/styles/settings.scss
+++ b/app/styles/settings.scss
@@ -27,6 +27,12 @@
             font-size: 16px;
             margin-top: 6px;
         }
+
+        .glyphicon-trash {
+            display: inline-block;
+            font-size: 14px;
+            margin-top: 2px;
+        }
     }
 
     button[type="submit"] {


### PR DESCRIPTION
Add a "Transfer Balance" setting that calls the account merge API to transfer the user's balance to a different account. The API call removes the account entry from the ledger, so when this request is complete all the wallet's gateways are removed to reflect the fact that the trust lines no longer exist.

Needs UX feedback. I used a trashcan icon, but that's probably not the correct icon until we make this a feature that deletes the user account also.

Fixes #10.
