### PR TITLE
Mark browsers without crypto unsupported

### DIFF
--- a/app/scripts/utilities/signingKeys.js
+++ b/app/scripts/utilities/signingKeys.js
@@ -11,7 +11,6 @@ var SigningKeys = function(seed){
   if(seed){
     seed = new stellar.Seed().parse_json(seed);
   } else {
-    Util.ensureEntropy();
     seed = new stellar.Seed().random();
   }
 

--- a/app/scripts/utilities/supported-browser.js
+++ b/app/scripts/utilities/supported-browser.js
@@ -9,6 +9,12 @@ function isSupportedBrowser() {
   if(!Modernizr.websockets)                           { return false; }
   if(!Modernizr.dataview)                             { return false; }
 
+  // Ensure cryptographically strong entropy
+  if (!((window.crypto   && window.crypto.getRandomValues) ||
+        (window.msCrypto && window.msCrypto.getRandomValues))) {
+    return false;
+  }
+
   // HACK: A specific version of Android's stock browser (AppleWebKit/534.30)
   // has a broken implementation of WebSocket. This can be removed if Modernizr
   // fixes the issue (https://github.com/Modernizr/Modernizr/issues/1399).

--- a/app/scripts/utilities/util.js
+++ b/app/scripts/utilities/util.js
@@ -33,34 +33,6 @@ Util.showTooltip = function (element, title, type, placement) {
     .tooltip('show');
 };
 
-/**
- * Seed the sjcl random function with Math.random() in the case where we are
- * on a crappy browser (IE) and we've yet to get enough entropy from the
- * sjcl entropy collector.
- *
- * it sucks, but this is our last minute fix for IE support.  Our fix going
- * forward will be to use window.msCrypto on ie11, and on ie10 request
- * some mouse movement from the user (maybe?).
- *
- */
-Util.ensureEntropy = function() {
-  var isEnough = function() {
-    return sjcl.random.isReady() !== sjcl.random._NOT_READY;
-  };
-
-  if(isEnough()){
-    return;
-  }
-
-  for (var i = 0; i < 8; i++) {
-    sjcl.random.addEntropy(Math.random(), 32, "Math.random()");
-  }
-
-  if(!isEnough()) {
-    throw "Unable to seed sjcl entropy pool";
-  }
-};
-
 Util.tryGet = function(rootObject, propertyChain) {
   var propertyNames = propertyChain.split('.');
 

--- a/app/scripts/utilities/wallet.js
+++ b/app/scripts/utilities/wallet.js
@@ -298,7 +298,6 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, ipCookie) 
   Wallet.prototype.saveLocal = function() {
     var self = this;
 
-    Util.ensureEntropy();
     var loginWalletKey = sjcl.random.randomWords(Wallet.SETTINGS.KEY_SIZE / 4);
     var encryptedWalletKey = Wallet.encryptData(this.key, loginWalletKey);
 
@@ -527,7 +526,6 @@ angular.module('stellarClient').factory('Wallet', function($q, $http, ipCookie) 
     var cipher = new sjcl.cipher[Wallet.SETTINGS.CIPHER_NAME](key);
 
     // Encrypt the blob data in CCM mode using AES and a random 96bit IV.
-    Util.ensureEntropy();
     var rawIV = sjcl.random.randomWords(3);
     var rawCipherText = sjcl.mode[Wallet.SETTINGS.MODE].encrypt(cipher, rawData, rawIV);
 

--- a/app/unsupported.html
+++ b/app/unsupported.html
@@ -70,7 +70,7 @@
               <h2 class="modalStatus-title">Oops!</h2>
               <p class="modalStatus-info">
                 <strong>We're sorry but it appears that your browser isn't supported by the Stellar client.</strong>
-                We need your browser to support Javascript, Websockets and Typed Arrays in order to correctly
+                We need your browser to support Javascript, Websockets, Crypto Module and Typed Arrays in order to correctly
                 function.
               </p>
               <p class="modalStatus-info">


### PR DESCRIPTION
Mark [browsers without crypto](http://caniuse.com/#search=crypto.getRandomValues) unsupported. Effectively, a new rule in `isSupportedBrowser()` drops support for IE10.