### PR TITLE
Prevent scientific notation when creating amount

### DIFF
--- a/app/scripts/services/payment-service.js
+++ b/app/scripts/services/payment-service.js
@@ -103,7 +103,7 @@ sc.service('Payment', function($rootScope, $q, StellarNetwork, Destination, Canc
   Payment.setAmount = function(value, currency) {
     clearPaths();
 
-    var amountString = (value || 0) + ' ' + currency;
+    var amountString = (value || 0).toFixed(16) + ' ' + currency;
     amount = new stellar.Amount.from_human(amountString);
 
     updatePaths();


### PR DESCRIPTION
Prevent javascript from converting `0.0000001` to scientific notation `1e-7`, because stellar-lib's Amount is unable to parse the string as a number. Allow 16 fixed decimal places in the number string. Amount will truncate the digits as needed.

Fixes #859.
