### PR TITLE
Show amount errors, unify errors and updatePaths()

### DIFF
--- a/app/templates/send-form.html
+++ b/app/templates/send-form.html
@@ -21,7 +21,7 @@
         <div class="form-group send-amount">
             <label for="amount" class="col-md-2">AMOUNT</label>
             <div class="col-md-4 send-amount-input">
-                <input name="amount" type="number" min="0" class="form-control" ng-model="sendFormModel.amount"/>
+                <input id="amount" name="amount" type="text" class="form-control" ng-model="sendFormModel.amount"/>
             </div>
             <div class="col-md-2">
 


### PR DESCRIPTION
Change the amount input type to text to bypass angular's silent validation.
Reject invalid amounts and show an error poptip the same way the destination is handled.
Properly reset the path status when the input is invalid.

![screen shot 2014-12-01 at 7 09 31 pm](https://cloud.githubusercontent.com/assets/3108007/5257454/b35b75a2-798d-11e4-8029-5e310c4f818c.png)
![screen shot 2014-12-01 at 7 09 58 pm](https://cloud.githubusercontent.com/assets/3108007/5257455/b35fbb94-798d-11e4-95b6-a2a77ac18d6d.png)
