### PR TITLE
change relative url to hash url

### DIFF
--- a/app/states/settings.html
+++ b/app/states/settings.html
@@ -1,7 +1,7 @@
 <div class="settings" ng-controller="SettingsCtrl">
     <div class="container">
         <div class="client-section">
-            <h1 class="title">Settings<span class="link-dashboard"><a href="/#/dashboard">&#8592; back to dashboard</a></span></h1>
+            <h1 class="title">Settings<span class="link-dashboard"><a href="#/dashboard">&#8592; back to dashboard</a></span></h1>
         </div>
 
         <flash-messages class="client-section" id="settings-flash-messages"></flash-messages>

--- a/app/states/trading.html
+++ b/app/states/trading.html
@@ -4,7 +4,7 @@
             <h1 class="title">
                 Trading
                 <span class="link-dashboard">
-                    <a href="/#/dashboard">&#8592; back to dashboard</a>
+                    <a href="#/dashboard">&#8592; back to dashboard</a>
                 </span>
             </h1>
         </div>


### PR DESCRIPTION
This only fixes the two links that have relative urls instead of hash urls. These links could instead be `ui-sref`.
Addresses immediate items in #1091 but there may be further items wanted (non-essential).
