### PR TITLE
Fix a bug introduced in #1120

### DIFF
--- a/app/scripts/controllers/send-controller.js
+++ b/app/scripts/controllers/send-controller.js
@@ -135,6 +135,7 @@ sc.controller('SendController', function($rootScope, $scope, $analytics, Stellar
     tx.payment($rootScope.account.Account, destination.address, amount.to_json());
 
     if (destination.destinationTag) {
+      destination.destinationTag = parseInt(destination.destinationTag);
       tx.destination_tag(destination.destinationTag);
     }
 


### PR DESCRIPTION
Changing destinationTag input type to "text" in #1120 resulted in change of variable type in controller (number -> string). This made StellarNetwork.remote.transaction.submit() fail because it expects destinationTag to be a number.