### PR TITLE
Show issuers on the trade confirmation page

### DIFF
--- a/app/scripts/controllers/trading-controller.js
+++ b/app/scripts/controllers/trading-controller.js
@@ -39,6 +39,17 @@ sc.controller('TradingCtrl', function($scope, $q, Trading, Gateways, singletonPr
     }
   };
 
+  $scope.currencyToString = function(currency) {
+    var result = currency.currency;
+
+    if(currency.issuer) {
+      var gateway = $scope.issuerToGateway(currency.issuer);
+      result += ' (' + gateway + ')';
+    }
+
+    return result;
+  };
+
   $scope.setCurrentOrderBook = singletonPromise(function() {
     var currencyPair = currentCurrencyPair();
 

--- a/app/templates/trading-form.html
+++ b/app/templates/trading-form.html
@@ -163,9 +163,9 @@
     <div class="offer-status confirm-trade" ng-show="state == 'confirm'">
         You are offering to <b><span ng-if="formData.tradeOperation === 'buy'">buy</span>
         <span ng-if="formData.tradeOperation === 'sell'">sell</span></b><br>
-        <b>{{ formData.baseAmount | roundAmount:formData.baseCurrency.currency }} {{ formData.baseCurrency.currency }}</b><br>
+        <b>{{ formData.baseAmount | roundAmount:formData.baseCurrency.currency }} {{ currencyToString(formData.baseCurrency) }}</b><br>
         for<br>
-        <b>{{ formData.counterAmount | roundAmount:formData.counterCurrency.currency }} {{ formData.counterCurrency.currency }}</b><br>
+        <b>{{ formData.counterAmount | roundAmount:formData.counterCurrency.currency }} {{ currencyToString(formData.counterCurrency) }}</b><br>
         at<br>
         <b>{{ formData.truePrice | roundedAmount:precision }} {{ formData.counterCurrency.currency }}/{{ formData.baseCurrency.currency }}</b><br>
         <div class="button-group">


### PR DESCRIPTION
Show the issuer (gateway) for the currency when confirming a trade.

Fixes #1049.

![screen shot 2015-01-09 at 4 54 58 pm](https://cloud.githubusercontent.com/assets/3108007/5689748/a30e4efc-9820-11e4-9752-c08d67d0bcb4.png)
_Note: The counter currency would have shown the issuer if it had one._