### PR TITLE
Changed states names to work after recent ui-sref commit

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -80,7 +80,7 @@ stellarClient.config(function($httpProvider, $stateProvider, $urlRouterProvider,
       authenticate: false,
       params: {'username': 0, 'totpRequired': 0}
     })
-    .state('recovery_v2', {
+    .state('recovery-v2', {
       url:         '/recovery-v2',
       templateUrl: 'states/recovery_v2.html',
       authenticate: false
@@ -95,7 +95,7 @@ stellarClient.config(function($httpProvider, $stateProvider, $urlRouterProvider,
       templateUrl: 'states/username_recovery.html',
       authenticate: false
     })
-    .state('lost-totp', {
+    .state('lost-2fa-device', {
       url:         '/lost-2fa-device',
       templateUrl: 'states/lost_2fa_device.html',
       authenticate: false


### PR DESCRIPTION
Changed two states names to work after changes introduced in #1127:
```patch
diff --git a/app/states/login_v2.html b/app/states/login_v2.html
index ec7a232..2c7bcb5 100644
--- a/app/states/login_v2.html
+++ b/app/states/login_v2.html
@@ -44,10 +44,10 @@ <h1 class="title">Unlock Wallet <span class="login-back"><a href="#" ng-click="g
       </div>
       <div class="form-group">
         <div class="col-sm-offset-3 col-sm-6">
-          <span class="recovery-info"><a href="#/recovery-v2">Forgot password?</a></span>
+          <span class="recovery-info"><a ui-sref="recovery-v2">Forgot password?</a></span>
         </div>
         <div class="col-sm-offset-3 col-sm-6" ng-show="totpRequired">
-          <span class="recovery-info"><a href="#/lost-2fa-device">Lost your 2FA device?</a></span>
+          <span class="recovery-info"><a ui-sref="lost-2fa-device">Lost your 2FA device?</a></span>
         </div>
       </div>
     </form>
```