### PR TITLE
Handle the fb_email_missing error

### DIFF
--- a/app/scripts/controllers/facebook-reward-controller.js
+++ b/app/scripts/controllers/facebook-reward-controller.js
@@ -52,6 +52,11 @@ sc.controller('FacebookRewardCtrl', function ($rootScope, $scope, $http, $q, $an
             title: "Your Facebook was updated too recently.",
             subtitle: "Please try again in a couple of days"
           };
+        case 'fb_email_missing':
+          return {
+            title: "Your Facebook account does not have an email address.",
+            subtitle: "Please add an email address to your Facebook account."
+          };
         case 'fake':
           // TODO: their account is fake
         case 'incomplete':
@@ -86,6 +91,12 @@ sc.controller('FacebookRewardCtrl', function ($rootScope, $scope, $http, $q, $an
           $scope.reward.error = {};
           $scope.reward.error.info = "As part of our ongoing efforts to prevent fraud, we temporarily deny facebook accounts that have been updated too recently.  Please try again in a couple of days.";
           $scope.reward.error.panel = "Sorry, your Facebook account was updated too recently";
+          $scope.reward.error.action = null;
+          break;
+        case 'fb_email_missing':
+          $scope.reward.error = {};
+          $scope.reward.error.info = "Your Facebook account does not have an email address.";
+          $scope.reward.error.panel = "Please add an email address to your Facebook account.";
           $scope.reward.error.action = null;
           break;
         case 'invalid_fb_email_token':

--- a/app/scripts/controllers/reward-pane.js
+++ b/app/scripts/controllers/reward-pane.js
@@ -39,6 +39,7 @@ sc.controller('RewardPaneCtrl', function ($http, $scope, $rootScope, $q, session
     'updated_too_recently': 'icon icon-clock',
     'ineligible': 'icon icon-lock', // TODO: Use yield sign icon.
     'fb_email_unverified': 'icon icon-clock',
+    'fb_email_missing': 'icon icon-clock',
   };
 
   /**

--- a/app/templates/reward-page.html
+++ b/app/templates/reward-page.html
@@ -9,7 +9,7 @@
     </div>
 
     <div ng-hide="reward.error">
-        <div class="content" ng-class="{active: reward.status == 'incomplete' || reward.status == 'pending' || reward.status == 'unverified' || reward.status == 'ineligible' || reward.status == 'updated_too_recently'}">
+        <div class="content" ng-class="{active: reward.status == 'incomplete' || reward.status == 'pending' || reward.status == 'unverified' || reward.status == 'ineligible' || reward.status == 'updated_too_recently' || reward.status == 'fb_email_missing'}">
             <div ng-include="reward.template"></div>
         </div>
 


### PR DESCRIPTION
Adds error messaging for the "fb_email_missing" state that occurs when a user does not have an email address associated with their facebook account.

Fixes #1136.