### PR TITLE
Bump angular-re-captcha version 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "stellar-lib": "0.10.1",
     "zeroclipboard": "2.1.6",
     "bignumber.js": "1.4.1",
-    "angular-re-captcha": "0.0.3",
+    "angular-re-captcha": "0.1.0",
     "angulartics": "0.17.1",
     "URIjs": "1.14.1"
   },


### PR DESCRIPTION
Bump angular-re-captcha version to 0.1.0 to fix #1137.

mllrsohn/angular-re-captcha#17