### PR TITLE
Added apply() to lost-2fa-device-controller

### DIFF
--- a/app/scripts/controllers/lost-2fa-device-controller.js
+++ b/app/scripts/controllers/lost-2fa-device-controller.js
@@ -31,6 +31,8 @@ angular.module('stellarClient').controller('Lost2FADeviceCtrl', function($scope,
         }
       });
       $scope.error = 'Unknown error. Please try again later.';
+    }).finally(function() {
+      $scope.$apply();
     });
   });
 });


### PR DESCRIPTION
Added `apply()` in lost-2fa-device controller. Requests were submitted but user had to click twice to see UI changes:
![](http://g.recordit.co/qzieId3JIl.gif)