### PR TITLE
Fixed $(...).tooltip is not a function

### DIFF
--- a/app/scripts/controllers/send-form-controller.js
+++ b/app/scripts/controllers/send-form-controller.js
@@ -162,7 +162,10 @@ sc.controller('SendFormController', function($rootScope, $scope, Payment, deboun
 
   function clearPoptip(elementId) {
     showError.cancel();
-    $('#' + elementId).tooltip('destroy');
+    var element = $('#' + elementId);
+    if (typeof element.tooltip === 'function') {
+      element.tooltip('destroy');
+    }
   }
 
   function showAddressFound(address) {


### PR DESCRIPTION
Fixes `$(...).tooltip is not a function` errors.
https://app.getsentry.com/stellarorg/stellar-client/?query=tooltip+is+not+a+function