### PR TITLE
fix dead link pointing to old docs

### DIFF
--- a/app/templates/manage-currencies.html
+++ b/app/templates/manage-currencies.html
@@ -9,7 +9,7 @@
         <alert type="info" ng-show="actionLinkAlertActive()" dismissible="true">
             You just clicked on a link that automatically lets you add a gateway. Complete this action by clicking "Trust {{foundGateway.domain}}" if you want to trust this gateway. Find out more <a href="https://www.stellar.org/learn/#Gateways_trust_and_credit">about trust</a>.
         </alert>
-        <p>Add a gateway to send and receive in a new currency with your account. Find out <a href="https://github.com/stellar/docs/blob/master/docs/Adding-Multiple-Currencies.md" target="_blank">more</a>.
+        <p>Add a gateway to send and receive in a new currency with your account. Find out <a href="https://github.com/stellar/docs/blob/master/old-docs/Adding-Multiple-Currencies.md" target="_blank">more</a>.
 
         <form class="form-inline">
             <div class="form-group">


### PR DESCRIPTION
This fixes a link pointing to a docs folder that was renamed old-docs.

Thank you Stellar public slack channel user yaseenhamdulay https://stellar-public.slack.com/archives/general/p1434531534000577