### PR TITLE
Update upgrade copy

### DIFF
--- a/app/templates/upgrade.html
+++ b/app/templates/upgrade.html
@@ -39,7 +39,7 @@
     </div>
     <h1>Upgraded!</h1>
 
-    <h2>You have {{balance}} lumens.</h2>
+    <h2>Your {{balance}} lumens will arrive soon.</h2>
 
     <span ng-if="balances">
       <p>You still have:</p>


### PR DESCRIPTION
After successful upgrade lumens are not sent right away. Instead, the payment is queued so in case of any errors or delays (ex. hot wallet balance too low) in the upgrade process users don't need to come back to the app - their lumens will arrive eventually.

I changed a single sentence in the upgrade view because some users were confused:

```
You have XXX lumens.
```

is now:

```
Your XXX lumens will arrive soon.
```

![zrzut ekranu 2016-04-27 o 12 50 26](https://cloud.githubusercontent.com/assets/464938/14850122/38e7ed22-0c77-11e6-8b8e-cc48a31cad95.png)

CC: @jessica-collier 
