### PR TITLE
Client side check to emphasize importance of copying secret key

### DIFF
--- a/app/templates/upgrade.html
+++ b/app/templates/upgrade.html
@@ -29,6 +29,12 @@
       Please copy your secret key NOW! After clicking "Upgrade" button below you will no longer be able to see your secret key and we WILL NOT be able to recover it. Protect your secret key—anyone who has it can access your account.
     </strong></center></p>
     <p>Read more about the <a href="https://www.stellar.org/blog/stellar-network-upgrade/" target="_blank">upgrade</a>.</p>
+    <p>Please type in your secret key to confirm.</p>
+    <div class="form-group">
+      <div class="col-sm-6">
+        <input class="form-control" ng-model="confirmSecretKey" autocomplete="off" /><br />
+      </div>
+    </div>
     <div class="form-group row" ng-if="error">
       <div class="errors col-sm-offset-1 col-sm-6">
         <div class="tip" ng-bind-html="error"></div>
@@ -37,7 +43,7 @@
     <div ng-if="showConfirmationCodeInput">
       <input type="text" class="confirmation-code" ng-model="$parent.$parent.confirmationCode" />
     </div>
-    <button ng-click="upgrade()" class="btn btn-default btn-primary submit">Upgrade and confirm secret key has been copied</button>
+    <button ng-click="upgrade()" class="btn btn-default btn-primary submit" ng-disabled="confirmSecretKey !== newNetworkSecretSeed">Upgrade and confirm secret key has been copied</button>
   </div>
 
   <div class="loading" ng-if="view === 'upgrading'">


### PR DESCRIPTION
To address the issue of users not copying down their secret key before upgrading, this minimal client side check forces user to copy  and acknowledge their secret key before upgrading their account.

Modeled after Github's warning before deleting a repo:

![screen shot 2018-02-15 at 4 44 09 pm](https://user-images.githubusercontent.com/16689974/36290426-f977cd8c-1279-11e8-954e-aae8e98fe64d.png)


## Before Typing in Secret Key

The upgrade button is disabled:

<img width="969" alt="screen shot 2018-02-15 at 5 56 10 pm" src="https://user-images.githubusercontent.com/16689974/36290438-0e323046-127a-11e8-9bad-1995b8bb4260.png">

## After Typing in Secret Key

the upgrade button is enabled:

<img width="508" alt="screen shot 2018-02-15 at 5 56 18 pm" src="https://user-images.githubusercontent.com/16689974/36290449-20291008-127a-11e8-9a4b-42931e127809.png">

## Full Process

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16689974/36290457-2a0b7930-127a-11e8-93ef-dde13c16ce5c.gif)